### PR TITLE
NVRAM v3 format support, refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,7 @@ version = "0.1.0"
 dependencies = [
  "adler32",
  "crc32fast",
+ "either",
  "indexmap 2.0.0",
  "nix",
 ]
@@ -153,6 +154,12 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "equivalent"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,8 +25,6 @@ version = "0.1.0"
 dependencies = [
  "adler32",
  "crc32fast",
- "either",
- "indexmap 2.0.0",
  "nix",
 ]
 
@@ -109,7 +107,7 @@ dependencies = [
  "atty",
  "bitflags 1.3.2",
  "clap_lex",
- "indexmap 1.9.3",
+ "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
@@ -156,18 +154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
-name = "either"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
-
-[[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,12 +186,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,17 +201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
-dependencies = [
- "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown",
 ]
 
 [[package]]
@@ -282,7 +252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
- "hashbrown 0.12.3",
+ "hashbrown",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,8 @@ name = "apple-nvram"
 version = "0.1.0"
 dependencies = [
  "adler32",
+ "crc32fast",
+ "indexmap 2.0.0",
  "nix",
 ]
 
@@ -106,7 +108,7 @@ dependencies = [
  "atty",
  "bitflags 1.3.2",
  "clap_lex",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim",
  "termcolor",
@@ -138,10 +140,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "getrandom"
@@ -176,6 +193,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,7 +214,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -242,7 +275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]

--- a/apple-nvram/Cargo.toml
+++ b/apple-nvram/Cargo.toml
@@ -13,5 +13,6 @@ repository = "https://github.com/WhatAmISupposedToPutHere/asahi-nvram"
 [dependencies]
 adler32 = "1"
 crc32fast = "1.3.2"
+either = "1.9.0"
 indexmap = "2.0.0"
 nix = "0.25"

--- a/apple-nvram/Cargo.toml
+++ b/apple-nvram/Cargo.toml
@@ -13,6 +13,4 @@ repository = "https://github.com/WhatAmISupposedToPutHere/asahi-nvram"
 [dependencies]
 adler32 = "1"
 crc32fast = "1.3.2"
-either = "1.9.0"
-indexmap = "2.0.0"
 nix = "0.25"

--- a/apple-nvram/Cargo.toml
+++ b/apple-nvram/Cargo.toml
@@ -12,4 +12,6 @@ repository = "https://github.com/WhatAmISupposedToPutHere/asahi-nvram"
 
 [dependencies]
 adler32 = "1"
+crc32fast = "1.3.2"
+indexmap = "2.0.0"
 nix = "0.25"

--- a/apple-nvram/src/lib.rs
+++ b/apple-nvram/src/lib.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 pub mod mtd;
-pub use mtd::erase_if_needed; // TODO: remove
 
 pub mod v1v2;
 pub mod v3;
@@ -82,13 +81,7 @@ pub trait Nvram<'a> {
     fn active_part_mut(&mut self) -> &mut dyn Partition<'a>;
     fn partitions(&self) -> Box<dyn Iterator<Item = &dyn Partition<'a>> + '_>;
     fn serialize(&self) -> Result<Vec<u8>>;
-    fn apply(&self, w: &mut dyn NvramWriter) -> Result<()> {
-        let data = self.serialize()?;
-        // TODO: only erase the bank that was actually modified
-        // (do not overwrite the whole nvram)
-        w.write_all(0, &data).map_err(|e| Error::ApplyError(e))?;
-        Ok(())
-    }
+    fn apply(&self, w: &mut dyn NvramWriter) -> Result<()>;
 }
 
 pub trait Partition<'a>: Display {

--- a/apple-nvram/src/lib.rs
+++ b/apple-nvram/src/lib.rs
@@ -145,6 +145,28 @@ pub enum Partition<'a, 'b> {
     V3(&'b v3::Partition<'a>),
 }
 
+impl<'a, 'b> Partition<'a, 'b>  {
+    pub fn variables(&self) -> impl Iterator<Item = Variable<'a, '_>> {
+        match self {
+            Partition::V1V2(p) => {
+                Either::Left(p.variables().map(|v| Variable::V1V2(v)))
+            }
+            Partition::V3(p) => {
+                Either::Right(p.variables().map(|v| Variable::V3(v)))
+            }
+        }
+    }
+}
+
+impl<'a, 'b> fmt::Display for Partition<'a, 'b> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Partition::V1V2(p) => fmt::Display::fmt(p, f),
+            Partition::V3(p) => fmt::Display::fmt(p, f),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum PartitionMut<'a, 'b> {
     V1V2(&'b mut v1v2::Partition<'a>),

--- a/apple-nvram/src/lib.rs
+++ b/apple-nvram/src/lib.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 use std::{
+    borrow::Cow,
     fmt::{Debug, Display, Formatter},
     fs::File,
-    os::unix::io::AsRawFd, borrow::Cow,
+    os::unix::io::AsRawFd,
 };
 
 use either::Either;
@@ -100,23 +101,15 @@ impl<'a> Nvram<'a> {
 
     pub fn serialize(&self) -> Result<Vec<u8>> {
         match self {
-            Nvram::V1V2(nvram) => {
-                nvram.serialize()
-            }
-            Nvram::V3(nvram) => {
-                nvram.serialize()
-            }
+            Nvram::V1V2(nvram) => nvram.serialize(),
+            Nvram::V3(nvram) => nvram.serialize(),
         }
     }
 
     pub fn prepare_for_write(&mut self) {
         match self {
-            Nvram::V1V2(nvram) => {
-                nvram.prepare_for_write()
-            }
-            Nvram::V3(nvram) => {
-                nvram.prepare_for_write()
-            }
+            Nvram::V1V2(nvram) => nvram.prepare_for_write(),
+            Nvram::V3(nvram) => nvram.prepare_for_write(),
         }
     }
 
@@ -129,12 +122,8 @@ impl<'a> Nvram<'a> {
 
     pub fn partitions(&self) -> impl Iterator<Item = Partition<'a, '_>> {
         match self {
-            Nvram::V1V2(nvram) => {
-                Either::Left(nvram.partitions().map(|p| Partition::V1V2(p)))
-            }
-            Nvram::V3(nvram) => {
-                Either::Right(nvram.partitions().map(|p| Partition::V3(p)))
-            }
+            Nvram::V1V2(nvram) => Either::Left(nvram.partitions().map(|p| Partition::V1V2(p))),
+            Nvram::V3(nvram) => Either::Right(nvram.partitions().map(|p| Partition::V3(p))),
         }
     }
 }
@@ -145,15 +134,11 @@ pub enum Partition<'a, 'b> {
     V3(&'b v3::Partition<'a>),
 }
 
-impl<'a> Partition<'a, '_>  {
+impl<'a> Partition<'a, '_> {
     pub fn variables(&self) -> impl Iterator<Item = Variable<'a, '_>> {
         match self {
-            Partition::V1V2(p) => {
-                Either::Left(p.variables().map(|v| Variable::V1V2(v)))
-            }
-            Partition::V3(p) => {
-                Either::Right(p.variables().map(|v| Variable::V3(v)))
-            }
+            Partition::V1V2(p) => Either::Left(p.variables().map(|v| Variable::V1V2(v))),
+            Partition::V3(p) => Either::Right(p.variables().map(|v| Variable::V3(v))),
         }
     }
 }
@@ -176,52 +161,37 @@ pub enum PartitionMut<'a, 'b> {
 impl<'a> PartitionMut<'a, '_> {
     pub fn get_variable(&self, key: &'a [u8]) -> Option<Variable<'a, '_>> {
         match self {
-            PartitionMut::V1V2(p) => {
-                p.get_variable(key).map(|v| Variable::V1V2(v))
-            }
-            PartitionMut::V3(p) => {
-                p.get_variable(key).map(|v| Variable::V3(v))
-            }
+            PartitionMut::V1V2(p) => p.get_variable(key).map(|v| Variable::V1V2(v)),
+            PartitionMut::V3(p) => p.get_variable(key).map(|v| Variable::V3(v)),
         }
     }
 
     pub fn insert_variable(&mut self, key: &'a [u8], value: Cow<'a, [u8]>, typ: VarType) {
         match self {
-            PartitionMut::V1V2(p) => {
-                p.insert_variable(key, value, typ)
-            },
-            PartitionMut::V3(p) => {
-                p.insert_variable(key, value, typ)
-            },
+            PartitionMut::V1V2(p) => p.insert_variable(key, value, typ),
+            PartitionMut::V3(p) => p.insert_variable(key, value, typ),
         };
     }
 
     pub fn remove_variable(&mut self, key: &'a [u8], typ: VarType) {
         match self {
-            PartitionMut::V1V2(p) => {
-                p.remove_variable(key, typ)
-            },
-            PartitionMut::V3(p) => {
-                p.remove_variable(key, typ)
-            },
+            PartitionMut::V1V2(p) => p.remove_variable(key, typ),
+            PartitionMut::V3(p) => p.remove_variable(key, typ),
         };
     }
 
     pub fn variables(&self) -> impl Iterator<Item = Variable<'a, '_>> {
         match self {
-            PartitionMut::V1V2(p) => {
-                Either::Left(p.variables().map(|v| Variable::V1V2(v)))
-            }
-            PartitionMut::V3(p) => {
-                Either::Right(p.variables().map(|v| Variable::V3(v)))
-            }
+            PartitionMut::V1V2(p) => Either::Left(p.variables().map(|v| Variable::V1V2(v))),
+            PartitionMut::V3(p) => Either::Right(p.variables().map(|v| Variable::V3(v))),
         }
     }
 }
 
 #[derive(Clone)]
 pub enum VarType {
-    Common, System
+    Common,
+    System,
 }
 
 impl Display for VarType {

--- a/apple-nvram/src/lib.rs
+++ b/apple-nvram/src/lib.rs
@@ -44,6 +44,7 @@ fn slice_find<T: PartialEq<T>>(ts: &[T], t: &T) -> Option<usize> {
 pub enum Error {
     ParseError,
     SectionTooBig,
+    ApplyError(std::io::Error),
 }
 
 type Result<T> = std::result::Result<T, Error>;
@@ -82,109 +83,6 @@ pub fn erase_if_needed(file: &File, size: usize) {
     }
 }
 
-// #[derive(Debug)]
-// pub enum Nvram<'a> {
-//     V1V2(v1v2::Nvram<'a>),
-//     V3(v3::Nvram<'a>),
-// }
-
-// impl<'a> Nvram<'a> {
-//     pub fn parse(nvr: &'a [u8]) -> Result<Nvram<'a>> {
-//         match (v3::Nvram::parse(nvr), v1v2::Nvram::parse(nvr)) {
-//             (Ok(nvram_v3), Err(_)) => Ok(Nvram::V3(nvram_v3)),
-//             (Err(_), Ok(nvram_v1v2)) => Ok(Nvram::V1V2(nvram_v1v2)),
-//             _ => Err(Error::ParseError),
-//         }
-//     }
-
-//     pub fn serialize(&self) -> Result<Vec<u8>> {
-//         match self {
-//             Nvram::V1V2(nvram) => nvram.serialize(),
-//             Nvram::V3(nvram) => nvram.serialize(),
-//         }
-//     }
-
-//     pub fn prepare_for_write(&mut self) {
-//         match self {
-//             Nvram::V1V2(nvram) => nvram.prepare_for_write(),
-//             Nvram::V3(nvram) => nvram.prepare_for_write(),
-//         }
-//     }
-
-//     pub fn active_part_mut(&mut self) -> PartitionMut<'a, '_> {
-//         match self {
-//             Nvram::V1V2(nvram) => PartitionMut::V1V2(nvram.active_part_mut()),
-//             Nvram::V3(nvram) => PartitionMut::V3(nvram.active_part_mut()),
-//         }
-//     }
-
-//     pub fn partitions(&self) -> impl Iterator<Item = Partition<'a, '_>> {
-//         match self {
-//             Nvram::V1V2(nvram) => Either::Left(nvram.partitions().map(|p| Partition::V1V2(p))),
-//             Nvram::V3(nvram) => Either::Right(nvram.partitions().map(|p| Partition::V3(p))),
-//         }
-//     }
-// }
-// #[derive(Debug)]
-// pub enum Partition<'a, 'b> {
-//     V1V2(&'b v1v2::Partition<'a>),
-//     V3(&'b v3::Partition<'a>),
-// }
-
-// impl<'a> Partition<'a, '_> {
-//     pub fn variables(&self) -> impl Iterator<Item = Variable<'a, '_>> {
-//         match self {
-//             Partition::V1V2(p) => Either::Left(p.variables().map(|v| Variable::V1V2(v))),
-//             Partition::V3(p) => Either::Right(p.variables().map(|v| Variable::V3(v))),
-//         }
-//     }
-// }
-
-// impl Display for Partition<'_, '_> {
-//     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-//         match *self {
-//             Partition::V1V2(p) => Display::fmt(p, f),
-//             Partition::V3(p) => Display::fmt(p, f),
-//         }
-//     }
-// }
-
-// #[derive(Debug)]
-// pub enum PartitionMut<'a, 'b> {
-//     V1V2(&'b mut v1v2::Partition<'a>),
-//     V3(&'b mut v3::Partition<'a>),
-// }
-
-// impl<'a> PartitionMut<'a, '_> {
-//     pub fn get_variable(&self, key: &'a [u8]) -> Option<Variable<'a, '_>> {
-//         match self {
-//             PartitionMut::V1V2(p) => p.get_variable(key).map(|v| Variable::V1V2(v)),
-//             PartitionMut::V3(p) => p.get_variable(key).map(|v| Variable::V3(v)),
-//         }
-//     }
-
-//     pub fn insert_variable(&mut self, key: &'a [u8], value: Cow<'a, [u8]>, typ: VarType) {
-//         match self {
-//             PartitionMut::V1V2(p) => p.insert_variable(key, value, typ),
-//             PartitionMut::V3(p) => p.insert_variable(key, value, typ),
-//         };
-//     }
-
-//     pub fn remove_variable(&mut self, key: &'a [u8], typ: VarType) {
-//         match self {
-//             PartitionMut::V1V2(p) => p.remove_variable(key, typ),
-//             PartitionMut::V3(p) => p.remove_variable(key, typ),
-//         };
-//     }
-
-//     pub fn variables(&self) -> impl Iterator<Item = Variable<'a, '_>> {
-//         match self {
-//             PartitionMut::V1V2(p) => Either::Left(p.variables().map(|v| Variable::V1V2(v))),
-//             PartitionMut::V3(p) => Either::Right(p.variables().map(|v| Variable::V3(v))),
-//         }
-//     }
-// }
-
 #[derive(Clone)]
 pub enum VarType {
     Common,
@@ -200,30 +98,6 @@ impl Display for VarType {
     }
 }
 
-// #[derive(Clone)]
-// pub enum Variable<'a, 'b> {
-//     V1V2(&'b v1v2::Variable<'a>),
-//     V3(&'b v3::Variable<'a>),
-// }
-
-// impl<'a> Variable<'a, '_> {
-//     pub fn value(&self) -> Cow<'a, [u8]> {
-//         match *self {
-//             Variable::V1V2(v) => v.value(),
-//             Variable::V3(v) => v.value(),
-//         }
-//     }
-// }
-
-// impl Display for Variable<'_, '_> {
-//     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-//         match *self {
-//             Variable::V1V2(v) => Display::fmt(v, f),
-//             Variable::V3(v) => Display::fmt(v, f),
-//         }
-//     }
-// }
-
 pub fn nvram_parse<'a>(nvr: &'a [u8]) -> Result<Box<dyn Nvram<'a> + 'a>> {
     match (v3::Nvram::parse(nvr), v1v2::Nvram::parse(nvr)) {
         (Ok(nvram_v3), Err(_)) => Ok(Box::new(nvram_v3)),
@@ -232,11 +106,22 @@ pub fn nvram_parse<'a>(nvr: &'a [u8]) -> Result<Box<dyn Nvram<'a> + 'a>> {
     }
 }
 
+pub trait NvramWriter {
+    fn write_all(&mut self, offset: usize, buf: &[u8]) -> std::io::Result<()>;
+}
+
 pub trait Nvram<'a> {
     fn prepare_for_write(&mut self);
     fn active_part_mut(&mut self) -> &mut dyn Partition<'a>;
     fn partitions(&self) -> Box<dyn Iterator<Item = &dyn Partition<'a>> + '_>;
     fn serialize(&self) -> Result<Vec<u8>>;
+    fn apply(&self, w: &mut dyn NvramWriter) -> Result<()> {
+        let data = self.serialize()?;
+        // TODO: only erase the bank that was actually modified
+        // (do not overwrite the whole nvram)
+        w.write_all(0, &data).map_err(|e| Error::ApplyError(e))?;
+        Ok(())
+    }
 }
 
 pub trait Partition<'a>: Display {

--- a/apple-nvram/src/lib.rs
+++ b/apple-nvram/src/lib.rs
@@ -7,6 +7,8 @@ use std::{
     os::unix::io::AsRawFd,
 };
 
+pub mod v3;
+
 pub struct UnescapeVal<I> {
     inner: I,
     esc_out: u8,
@@ -188,7 +190,7 @@ impl Section<'_> {
         Ok(Section { header, values })
     }
     fn size_bytes(&self) -> usize {
-        (self.header.size * 16) as usize
+        self.header.size as usize * 16
     }
     pub fn serialize(&self, v: &mut Vec<u8>) -> Result<()> {
         let start_size = v.len();

--- a/apple-nvram/src/lib.rs
+++ b/apple-nvram/src/lib.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 use std::{
-    fmt::{Debug, self},
+    fmt::{Debug, Display, Formatter},
     fs::File,
     os::unix::io::AsRawFd, borrow::Cow,
 };
@@ -145,7 +145,7 @@ pub enum Partition<'a, 'b> {
     V3(&'b v3::Partition<'a>),
 }
 
-impl<'a, 'b> Partition<'a, 'b>  {
+impl<'a> Partition<'a, '_>  {
     pub fn variables(&self) -> impl Iterator<Item = Variable<'a, '_>> {
         match self {
             Partition::V1V2(p) => {
@@ -158,11 +158,11 @@ impl<'a, 'b> Partition<'a, 'b>  {
     }
 }
 
-impl<'a, 'b> fmt::Display for Partition<'a, 'b> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl Display for Partition<'_, '_> {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match *self {
-            Partition::V1V2(p) => fmt::Display::fmt(p, f),
-            Partition::V3(p) => fmt::Display::fmt(p, f),
+            Partition::V1V2(p) => Display::fmt(p, f),
+            Partition::V3(p) => Display::fmt(p, f),
         }
     }
 }
@@ -173,7 +173,7 @@ pub enum PartitionMut<'a, 'b> {
     V3(&'b mut v3::Partition<'a>),
 }
 
-impl<'a, 'b> PartitionMut<'a, 'b> {
+impl<'a> PartitionMut<'a, '_> {
     pub fn get_variable(&self, key: &'a [u8]) -> Option<Variable<'a, '_>> {
         match self {
             PartitionMut::V1V2(p) => {
@@ -224,8 +224,8 @@ pub enum VarType {
     Common, System
 }
 
-impl fmt::Display for VarType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl Display for VarType {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             &VarType::Common => write!(f, "common"),
             &VarType::System => write!(f, "system"),
@@ -248,11 +248,11 @@ impl<'a> Variable<'a, '_> {
     }
 }
 
-impl<'a, 'b> fmt::Display for Variable<'a, 'b> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl Display for Variable<'_, '_> {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match *self {
-            Variable::V1V2(v) => fmt::Display::fmt(v, f),
-            Variable::V3(v) => fmt::Display::fmt(v, f),
+            Variable::V1V2(v) => Display::fmt(v, f),
+            Variable::V3(v) => Display::fmt(v, f),
         }
     }
 }

--- a/apple-nvram/src/lib.rs
+++ b/apple-nvram/src/lib.rs
@@ -1,74 +1,14 @@
 // SPDX-License-Identifier: MIT
 use std::{
-    borrow::Cow,
-    collections::HashMap,
-    fmt::{Debug, Formatter, self},
+    fmt::{Debug, self},
     fs::File,
-    os::unix::io::AsRawFd,
+    os::unix::io::AsRawFd, borrow::Cow,
 };
+
+use either::Either;
 
 pub mod v1v2;
 pub mod v3;
-
-pub struct UnescapeVal<I> {
-    inner: I,
-    esc_out: u8,
-    remaining: u8,
-}
-
-impl<I> UnescapeVal<I>
-where
-    I: Iterator<Item = u8>,
-{
-    pub fn new(inner: I) -> Self {
-        Self {
-            inner,
-            esc_out: 0,
-            remaining: 0,
-        }
-    }
-}
-
-impl<I> Iterator for UnescapeVal<I>
-where
-    I: Iterator<Item = u8>,
-{
-    type Item = u8;
-    fn next(&mut self) -> Option<u8> {
-        if self.remaining != 0 {
-            self.remaining -= 1;
-            return Some(self.esc_out);
-        }
-        if let Some(n) = self.inner.next() {
-            if n != 0xFF {
-                return Some(n);
-            }
-            let count = self.inner.next()?;
-            self.esc_out = if count & 0x80 == 0 { 0 } else { 0xFF };
-            self.remaining = (count & 0x7F) - 1;
-            Some(self.esc_out)
-        } else {
-            None
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct CHRPHeader<'a> {
-    pub name: &'a [u8],
-    pub size: u16,
-    pub signature: u8,
-}
-
-impl Debug for CHRPHeader<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CHRPHeader")
-            .field("name", &String::from_utf8_lossy(self.name).into_owned())
-            .field("size", &self.size)
-            .field("signature", &self.signature)
-            .finish()
-    }
-}
 
 fn chrp_checksum_add(lhs: u8, rhs: u8) -> u8 {
     let (out, carry) = lhs.overflowing_add(rhs);
@@ -109,269 +49,6 @@ pub enum Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
-impl CHRPHeader<'_> {
-    pub fn parse(nvr: &[u8]) -> Result<CHRPHeader<'_>> {
-        let signature = nvr[0];
-        let cksum = nvr[1];
-        let size = u16::from_le_bytes(nvr[2..4].try_into().unwrap());
-        let name = slice_rstrip(&nvr[4..16], &0);
-        let cand = CHRPHeader {
-            name,
-            size,
-            signature,
-        };
-        if cand.checksum() != cksum {
-            return Err(Error::ParseError);
-        }
-        Ok(cand)
-    }
-    fn checksum(&self) -> u8 {
-        let mut cksum = 0;
-        for &u in self.name {
-            cksum = chrp_checksum_add(cksum, u);
-        }
-        cksum = chrp_checksum_add(cksum, self.signature);
-        cksum = chrp_checksum_add(cksum, (self.size & 0xFF) as u8);
-        chrp_checksum_add(cksum, (self.size >> 8) as u8)
-    }
-
-    pub fn serialize(&self, v: &mut Vec<u8>) {
-        v.push(self.signature);
-        v.push(self.checksum());
-        v.extend_from_slice(&self.size.to_le_bytes());
-        v.extend_from_slice(self.name);
-        for _ in 0..(12 - self.name.len()) {
-            v.push(0);
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct Variable<'a> {
-    pub key: &'a [u8],
-    pub value: Cow<'a, [u8]>,
-    pub typ: VarType,
-}
-
-impl Variable<'_> {
-    pub fn new<'a>(key: &'a [u8], value: &'a [u8], typ: VarType) -> Variable<'a> {
-        Variable {
-            key,
-            value: Cow::Borrowed(value),
-            typ,
-        }
-    }
-}
-
-impl<'a> fmt::Display for Variable<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let key = String::from_utf8_lossy(self.key);
-        let mut value = String::new();
-        for c in UnescapeVal::new(self.value.iter().copied()) {
-            if (c as char).is_ascii() && !(c as char).is_ascii_control() {
-                value.push(c as char);
-            } else {
-                value.push_str(&format!("%{c:02x}"));
-            }
-        }
-
-        let value: String = value.chars().take(128).collect();
-        write!(f, "{}:{}={}", self.typ, key, value)
-    }
-}
-
-#[derive(Clone)]
-pub struct Section<'a> {
-    pub header: CHRPHeader<'a>,
-    pub values: HashMap<&'a [u8], Variable<'a>>,
-}
-
-impl Section<'_> {
-    pub fn parse(mut nvr: &[u8]) -> Result<Section<'_>> {
-        let header = CHRPHeader::parse(&nvr[..16])?;
-        nvr = &nvr[16..];
-        let mut values = HashMap::new();
-        loop {
-            let zero = slice_find(nvr, &0);
-            if zero.is_none() {
-                break;
-            }
-            let zero = zero.unwrap();
-            let cand = &nvr[..zero];
-            let eq = slice_find(cand, &b'=');
-            if eq.is_none() {
-                break;
-            }
-            let eq = eq.unwrap();
-            let key = &cand[..eq];
-            let typ = if header.name == b"common" {
-                VarType::Common
-            } else {
-                VarType::System
-            };
-            values.insert(key, Variable::new(key, &cand[(eq + 1)..], typ));
-            nvr = &nvr[(zero + 1)..]
-        }
-        Ok(Section { header, values })
-    }
-    fn size_bytes(&self) -> usize {
-        self.header.size as usize * 16
-    }
-    pub fn serialize(&self, v: &mut Vec<u8>) -> Result<()> {
-        let start_size = v.len();
-        self.header.serialize(v);
-        for val in self.values.values() {
-            v.extend_from_slice(val.key);
-            v.push(b'=');
-            v.extend_from_slice(&val.value);
-            v.push(0);
-        }
-        let my_size = v.len() - start_size;
-        if my_size > self.size_bytes() {
-            return Err(Error::SectionTooBig);
-        }
-        for _ in 0..(self.size_bytes() - my_size) {
-            v.push(0);
-        }
-        Ok(())
-    }
-}
-
-struct SectionDebug<'a, 'b>(&'a Section<'b>);
-impl Debug for SectionDebug<'_, '_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut m = f.debug_map();
-        for v in self.0.values.values() {
-            m.entry(
-                &String::from_utf8_lossy(v.key).into_owned(),
-                &String::from_utf8_lossy(
-                    &UnescapeVal::new(v.value.iter().copied()).collect::<Vec<_>>(),
-                )
-                .into_owned(),
-            );
-        }
-        m.finish()
-    }
-}
-
-impl Debug for Section<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Section")
-            .field("header", &self.header)
-            .field("values", &SectionDebug(self))
-            .finish()
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct Partition<'a> {
-    pub header: CHRPHeader<'a>,
-    pub generation: u32,
-    pub common: Section<'a>,
-    pub system: Section<'a>,
-}
-
-impl Partition<'_> {
-    pub fn parse(nvr: &[u8]) -> Result<Partition<'_>> {
-        let header = CHRPHeader::parse(&nvr[..16])?;
-        if header.name != b"nvram" {
-            return Err(Error::ParseError);
-        }
-        let adler = u32::from_le_bytes(nvr[16..20].try_into().unwrap());
-        let generation = u32::from_le_bytes(nvr[20..24].try_into().unwrap());
-        let sec1 = Section::parse(&nvr[32..])?;
-        let sec2 = Section::parse(&nvr[(32 + sec1.size_bytes())..])?;
-        let calc_adler =
-            adler32::adler32(&nvr[20..(32 + sec1.size_bytes() + sec2.size_bytes())]).unwrap();
-        if adler != calc_adler {
-            return Err(Error::ParseError);
-        }
-        let mut com = None;
-        let mut sys = None;
-        if sec1.header.name == b"common" {
-            com = Some(sec1);
-        } else if sec1.header.name == b"system" {
-            sys = Some(sec1);
-        }
-        if sec2.header.name == b"common" {
-            com = Some(sec2);
-        } else if sec2.header.name == b"system" {
-            sys = Some(sec2);
-        }
-        if com.is_none() || sys.is_none() {
-            return Err(Error::ParseError);
-        }
-        Ok(Partition {
-            header,
-            generation,
-            common: com.unwrap(),
-            system: sys.unwrap(),
-        })
-    }
-    fn size_bytes(&self) -> usize {
-        32 + self.common.size_bytes() + self.system.size_bytes()
-    }
-    pub fn serialize(&self, v: &mut Vec<u8>) -> Result<()> {
-        self.header.serialize(v);
-        v.extend_from_slice(&[0; 4]);
-        let adler_start = v.len();
-        v.extend_from_slice(&self.generation.to_le_bytes());
-        v.extend_from_slice(&[0; 8]);
-        self.common.serialize(v)?;
-        self.system.serialize(v)?;
-        let adler_end = v.len();
-        let adler = adler32::adler32(&v[adler_start..adler_end]).unwrap();
-        v[(adler_start - 4)..adler_start].copy_from_slice(&adler.to_le_bytes());
-        Ok(())
-    }
-}
-
-#[derive(Debug)]
-pub struct Nvram<'a> {
-    pub partitions: [Partition<'a>; 2],
-    pub active: usize,
-}
-
-impl<'a> Nvram<'a> {
-    pub fn parse(nvr: &[u8]) -> Result<Nvram<'_>> {
-        let p1;
-        let p2;
-        match (Partition::parse(nvr), Partition::parse(&nvr[0x10000..])) {
-            (Err(err), Err(_)) => return Err(err),
-            (Ok(p1r), Err(_)) => {
-                p1 = p1r;
-                p2 = p1.clone();
-            }
-            (Err(_), Ok(p2r)) => {
-                p2 = p2r;
-                p1 = p2.clone();
-            }
-            (Ok(p1r), Ok(p2r)) => {
-                p1 = p1r;
-                p2 = p2r;
-            }
-        }
-        let active = if p1.generation > p2.generation { 0 } else { 1 };
-        let partitions = [p1, p2];
-        Ok(Nvram { partitions, active })
-    }
-    pub fn serialize(&self) -> Result<Vec<u8>> {
-        let mut v = Vec::with_capacity(self.partitions[0].size_bytes() * 2);
-        self.partitions[0].serialize(&mut v)?;
-        self.partitions[1].serialize(&mut v)?;
-        Ok(v)
-    }
-    pub fn prepare_for_write(&mut self) {
-        let inactive = 1 - self.active;
-        self.partitions[inactive] = self.partitions[self.active].clone();
-        self.partitions[inactive].generation += 1;
-        self.active = inactive;
-    }
-    pub fn active_part_mut(&mut self) -> &mut Partition<'a> {
-        &mut self.partitions[self.active]
-    }
-}
-
 #[repr(C)]
 pub struct EraseInfoUser {
     start: u32,
@@ -406,6 +83,120 @@ pub fn erase_if_needed(file: &File, size: usize) {
     }
 }
 
+#[derive(Debug)]
+pub enum Nvram<'a> {
+    V1V2(v1v2::Nvram<'a>),
+    V3(v3::Nvram<'a>),
+}
+
+impl<'a> Nvram<'a> {
+    pub fn parse(nvr: &'a [u8]) -> Result<Nvram<'a>> {
+        match (v3::Nvram::parse(nvr), v1v2::Nvram::parse(nvr)) {
+            (Ok(nvram_v3), Err(_)) => Ok(Nvram::V3(nvram_v3)),
+            (Err(_), Ok(nvram_v1v2)) => Ok(Nvram::V1V2(nvram_v1v2)),
+            _ => Err(Error::ParseError),
+        }
+    }
+
+    pub fn serialize(&'a self) -> Result<Vec<u8>> {
+        match self {
+            Nvram::V1V2(nvram) => {
+                nvram.serialize()
+            }
+            Nvram::V3(nvram) => {
+                nvram.serialize()
+            }
+        }
+    }
+
+    pub fn prepare_for_write(&mut self) {
+        match self {
+            Nvram::V1V2(nvram) => {
+                nvram.prepare_for_write()
+            }
+            Nvram::V3(nvram) => {
+                nvram.prepare_for_write()
+            }
+        }
+    }
+
+    pub fn active_part_mut(&mut self) -> PartitionMut<'a, '_> {
+        match self {
+            Nvram::V1V2(nvram) => PartitionMut::V1V2(nvram.active_part_mut()),
+            Nvram::V3(nvram) => PartitionMut::V3(nvram.active_part_mut()),
+        }
+    }
+
+    pub fn partitions(&self) -> impl Iterator<Item = Partition<'a, '_>> {
+        match self {
+            Nvram::V1V2(nvram) => {
+                Either::Left(nvram.partitions().map(|p| Partition::V1V2(p)))
+            }
+            Nvram::V3(nvram) => {
+                Either::Right(nvram.partitions().map(|p| Partition::V3(p)))
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Partition<'a, 'b> {
+    V1V2(&'b v1v2::Partition<'a>),
+    V3(&'b v3::Partition<'a>),
+}
+
+#[derive(Debug)]
+pub enum PartitionMut<'a, 'b> {
+    V1V2(&'b mut v1v2::Partition<'a>),
+    V3(&'b mut v3::Partition<'a>),
+}
+
+impl<'a, 'b> PartitionMut<'a, 'b> {
+    pub fn get_variable(&self, key: &'a [u8]) -> Option<Variable<'a, '_>> {
+        match self {
+            PartitionMut::V1V2(p) => {
+                p.get_variable(key).map(|v| Variable::V1V2(v))
+            }
+            PartitionMut::V3(p) => {
+                p.get_variable(key).map(|v| Variable::V3(v))
+            }
+        }
+    }
+
+    pub fn insert_variable(&mut self, key: &'a [u8], value: Cow<'a, [u8]>, typ: VarType) {
+        match self {
+            PartitionMut::V1V2(p) => {
+                p.insert_variable(key, value, typ)
+            },
+            PartitionMut::V3(p) => {
+                p.insert_variable(key, value, typ)
+            },
+        };
+    }
+
+    pub fn remove_variable(&mut self, key: &'a [u8], typ: VarType) {
+        match self {
+            PartitionMut::V1V2(p) => {
+                p.remove_variable(key, typ)
+            },
+            PartitionMut::V3(p) => {
+                p.remove_variable(key, typ)
+            },
+        };
+    }
+
+    pub fn variables(&self) -> impl Iterator<Item = Variable<'a, '_>> {
+        match self {
+            PartitionMut::V1V2(p) => {
+                Either::Left(p.variables().map(|v| Variable::V1V2(v)))
+            }
+            PartitionMut::V3(p) => {
+                Either::Right(p.variables().map(|v| Variable::V3(v)))
+            }
+        }
+    }
+}
+
 #[derive(Clone)]
 pub enum VarType {
     Common, System
@@ -416,6 +207,30 @@ impl fmt::Display for VarType {
         match self {
             &VarType::Common => write!(f, "common"),
             &VarType::System => write!(f, "system"),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum Variable<'a, 'b> {
+    V1V2(&'b v1v2::Variable<'a>),
+    V3(&'b v3::Variable<'a>),
+}
+
+impl<'a> Variable<'a, '_> {
+    pub fn value(&self) -> Cow<'a, [u8]> {
+        match *self {
+            Variable::V1V2(v) => v.value(),
+            Variable::V3(v) => v.value(),
+        }
+    }
+}
+
+impl<'a, 'b> fmt::Display for Variable<'a, 'b> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Variable::V1V2(v) => fmt::Display::fmt(v, f),
+            Variable::V3(v) => fmt::Display::fmt(v, f),
         }
     }
 }

--- a/apple-nvram/src/lib.rs
+++ b/apple-nvram/src/lib.rs
@@ -6,8 +6,6 @@ use std::{
     os::unix::io::AsRawFd,
 };
 
-use either::Either;
-
 pub mod v1v2;
 pub mod v3;
 
@@ -84,109 +82,108 @@ pub fn erase_if_needed(file: &File, size: usize) {
     }
 }
 
-#[derive(Debug)]
-pub enum Nvram<'a> {
-    V1V2(v1v2::Nvram<'a>),
-    V3(v3::Nvram<'a>),
-}
+// #[derive(Debug)]
+// pub enum Nvram<'a> {
+//     V1V2(v1v2::Nvram<'a>),
+//     V3(v3::Nvram<'a>),
+// }
 
-impl<'a> Nvram<'a> {
-    pub fn parse(nvr: &'a [u8]) -> Result<Nvram<'a>> {
-        match (v3::Nvram::parse(nvr), v1v2::Nvram::parse(nvr)) {
-            (Ok(nvram_v3), Err(_)) => Ok(Nvram::V3(nvram_v3)),
-            (Err(_), Ok(nvram_v1v2)) => Ok(Nvram::V1V2(nvram_v1v2)),
-            _ => Err(Error::ParseError),
-        }
-    }
+// impl<'a> Nvram<'a> {
+//     pub fn parse(nvr: &'a [u8]) -> Result<Nvram<'a>> {
+//         match (v3::Nvram::parse(nvr), v1v2::Nvram::parse(nvr)) {
+//             (Ok(nvram_v3), Err(_)) => Ok(Nvram::V3(nvram_v3)),
+//             (Err(_), Ok(nvram_v1v2)) => Ok(Nvram::V1V2(nvram_v1v2)),
+//             _ => Err(Error::ParseError),
+//         }
+//     }
 
-    pub fn serialize(&self) -> Result<Vec<u8>> {
-        match self {
-            Nvram::V1V2(nvram) => nvram.serialize(),
-            Nvram::V3(nvram) => nvram.serialize(),
-        }
-    }
+//     pub fn serialize(&self) -> Result<Vec<u8>> {
+//         match self {
+//             Nvram::V1V2(nvram) => nvram.serialize(),
+//             Nvram::V3(nvram) => nvram.serialize(),
+//         }
+//     }
 
-    pub fn prepare_for_write(&mut self) {
-        match self {
-            Nvram::V1V2(nvram) => nvram.prepare_for_write(),
-            Nvram::V3(nvram) => nvram.prepare_for_write(),
-        }
-    }
+//     pub fn prepare_for_write(&mut self) {
+//         match self {
+//             Nvram::V1V2(nvram) => nvram.prepare_for_write(),
+//             Nvram::V3(nvram) => nvram.prepare_for_write(),
+//         }
+//     }
 
-    pub fn active_part_mut(&mut self) -> PartitionMut<'a, '_> {
-        match self {
-            Nvram::V1V2(nvram) => PartitionMut::V1V2(nvram.active_part_mut()),
-            Nvram::V3(nvram) => PartitionMut::V3(nvram.active_part_mut()),
-        }
-    }
+//     pub fn active_part_mut(&mut self) -> PartitionMut<'a, '_> {
+//         match self {
+//             Nvram::V1V2(nvram) => PartitionMut::V1V2(nvram.active_part_mut()),
+//             Nvram::V3(nvram) => PartitionMut::V3(nvram.active_part_mut()),
+//         }
+//     }
 
-    pub fn partitions(&self) -> impl Iterator<Item = Partition<'a, '_>> {
-        match self {
-            Nvram::V1V2(nvram) => Either::Left(nvram.partitions().map(|p| Partition::V1V2(p))),
-            Nvram::V3(nvram) => Either::Right(nvram.partitions().map(|p| Partition::V3(p))),
-        }
-    }
-}
+//     pub fn partitions(&self) -> impl Iterator<Item = Partition<'a, '_>> {
+//         match self {
+//             Nvram::V1V2(nvram) => Either::Left(nvram.partitions().map(|p| Partition::V1V2(p))),
+//             Nvram::V3(nvram) => Either::Right(nvram.partitions().map(|p| Partition::V3(p))),
+//         }
+//     }
+// }
+// #[derive(Debug)]
+// pub enum Partition<'a, 'b> {
+//     V1V2(&'b v1v2::Partition<'a>),
+//     V3(&'b v3::Partition<'a>),
+// }
 
-#[derive(Debug)]
-pub enum Partition<'a, 'b> {
-    V1V2(&'b v1v2::Partition<'a>),
-    V3(&'b v3::Partition<'a>),
-}
+// impl<'a> Partition<'a, '_> {
+//     pub fn variables(&self) -> impl Iterator<Item = Variable<'a, '_>> {
+//         match self {
+//             Partition::V1V2(p) => Either::Left(p.variables().map(|v| Variable::V1V2(v))),
+//             Partition::V3(p) => Either::Right(p.variables().map(|v| Variable::V3(v))),
+//         }
+//     }
+// }
 
-impl<'a> Partition<'a, '_> {
-    pub fn variables(&self) -> impl Iterator<Item = Variable<'a, '_>> {
-        match self {
-            Partition::V1V2(p) => Either::Left(p.variables().map(|v| Variable::V1V2(v))),
-            Partition::V3(p) => Either::Right(p.variables().map(|v| Variable::V3(v))),
-        }
-    }
-}
+// impl Display for Partition<'_, '_> {
+//     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+//         match *self {
+//             Partition::V1V2(p) => Display::fmt(p, f),
+//             Partition::V3(p) => Display::fmt(p, f),
+//         }
+//     }
+// }
 
-impl Display for Partition<'_, '_> {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        match *self {
-            Partition::V1V2(p) => Display::fmt(p, f),
-            Partition::V3(p) => Display::fmt(p, f),
-        }
-    }
-}
+// #[derive(Debug)]
+// pub enum PartitionMut<'a, 'b> {
+//     V1V2(&'b mut v1v2::Partition<'a>),
+//     V3(&'b mut v3::Partition<'a>),
+// }
 
-#[derive(Debug)]
-pub enum PartitionMut<'a, 'b> {
-    V1V2(&'b mut v1v2::Partition<'a>),
-    V3(&'b mut v3::Partition<'a>),
-}
+// impl<'a> PartitionMut<'a, '_> {
+//     pub fn get_variable(&self, key: &'a [u8]) -> Option<Variable<'a, '_>> {
+//         match self {
+//             PartitionMut::V1V2(p) => p.get_variable(key).map(|v| Variable::V1V2(v)),
+//             PartitionMut::V3(p) => p.get_variable(key).map(|v| Variable::V3(v)),
+//         }
+//     }
 
-impl<'a> PartitionMut<'a, '_> {
-    pub fn get_variable(&self, key: &'a [u8]) -> Option<Variable<'a, '_>> {
-        match self {
-            PartitionMut::V1V2(p) => p.get_variable(key).map(|v| Variable::V1V2(v)),
-            PartitionMut::V3(p) => p.get_variable(key).map(|v| Variable::V3(v)),
-        }
-    }
+//     pub fn insert_variable(&mut self, key: &'a [u8], value: Cow<'a, [u8]>, typ: VarType) {
+//         match self {
+//             PartitionMut::V1V2(p) => p.insert_variable(key, value, typ),
+//             PartitionMut::V3(p) => p.insert_variable(key, value, typ),
+//         };
+//     }
 
-    pub fn insert_variable(&mut self, key: &'a [u8], value: Cow<'a, [u8]>, typ: VarType) {
-        match self {
-            PartitionMut::V1V2(p) => p.insert_variable(key, value, typ),
-            PartitionMut::V3(p) => p.insert_variable(key, value, typ),
-        };
-    }
+//     pub fn remove_variable(&mut self, key: &'a [u8], typ: VarType) {
+//         match self {
+//             PartitionMut::V1V2(p) => p.remove_variable(key, typ),
+//             PartitionMut::V3(p) => p.remove_variable(key, typ),
+//         };
+//     }
 
-    pub fn remove_variable(&mut self, key: &'a [u8], typ: VarType) {
-        match self {
-            PartitionMut::V1V2(p) => p.remove_variable(key, typ),
-            PartitionMut::V3(p) => p.remove_variable(key, typ),
-        };
-    }
-
-    pub fn variables(&self) -> impl Iterator<Item = Variable<'a, '_>> {
-        match self {
-            PartitionMut::V1V2(p) => Either::Left(p.variables().map(|v| Variable::V1V2(v))),
-            PartitionMut::V3(p) => Either::Right(p.variables().map(|v| Variable::V3(v))),
-        }
-    }
-}
+//     pub fn variables(&self) -> impl Iterator<Item = Variable<'a, '_>> {
+//         match self {
+//             PartitionMut::V1V2(p) => Either::Left(p.variables().map(|v| Variable::V1V2(v))),
+//             PartitionMut::V3(p) => Either::Right(p.variables().map(|v| Variable::V3(v))),
+//         }
+//     }
+// }
 
 #[derive(Clone)]
 pub enum VarType {
@@ -203,26 +200,52 @@ impl Display for VarType {
     }
 }
 
-#[derive(Clone)]
-pub enum Variable<'a, 'b> {
-    V1V2(&'b v1v2::Variable<'a>),
-    V3(&'b v3::Variable<'a>),
-}
+// #[derive(Clone)]
+// pub enum Variable<'a, 'b> {
+//     V1V2(&'b v1v2::Variable<'a>),
+//     V3(&'b v3::Variable<'a>),
+// }
 
-impl<'a> Variable<'a, '_> {
-    pub fn value(&self) -> Cow<'a, [u8]> {
-        match *self {
-            Variable::V1V2(v) => v.value(),
-            Variable::V3(v) => v.value(),
-        }
+// impl<'a> Variable<'a, '_> {
+//     pub fn value(&self) -> Cow<'a, [u8]> {
+//         match *self {
+//             Variable::V1V2(v) => v.value(),
+//             Variable::V3(v) => v.value(),
+//         }
+//     }
+// }
+
+// impl Display for Variable<'_, '_> {
+//     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+//         match *self {
+//             Variable::V1V2(v) => Display::fmt(v, f),
+//             Variable::V3(v) => Display::fmt(v, f),
+//         }
+//     }
+// }
+
+pub fn nvram_parse<'a>(nvr: &'a [u8]) -> Result<Box<dyn Nvram<'a> + 'a>> {
+    match (v3::Nvram::parse(nvr), v1v2::Nvram::parse(nvr)) {
+        (Ok(nvram_v3), Err(_)) => Ok(Box::new(nvram_v3)),
+        (Err(_), Ok(nvram_v1v2)) => Ok(Box::new(nvram_v1v2)),
+        _ => Err(Error::ParseError),
     }
 }
 
-impl Display for Variable<'_, '_> {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        match *self {
-            Variable::V1V2(v) => Display::fmt(v, f),
-            Variable::V3(v) => Display::fmt(v, f),
-        }
-    }
+pub trait Nvram<'a> {
+    fn prepare_for_write(&mut self);
+    fn active_part_mut(&mut self) -> &mut dyn Partition<'a>;
+    fn partitions(&self) -> Box<dyn Iterator<Item = &dyn Partition<'a>> + '_>;
+    fn serialize(&self) -> Result<Vec<u8>>;
+}
+
+pub trait Partition<'a>: Display {
+    fn variables(&self) -> Box<dyn Iterator<Item = &dyn Variable<'a>> + '_>;
+    fn get_variable(&self, key: &'a [u8]) -> Option<&dyn Variable<'a>>;
+    fn insert_variable(&mut self, key: &'a [u8], value: Cow<'a, [u8]>, typ: VarType);
+    fn remove_variable(&mut self, key: &'a [u8], typ: VarType);
+}
+
+pub trait Variable<'a>: Display {
+    fn value(&self) -> Cow<'a, [u8]>;
 }

--- a/apple-nvram/src/lib.rs
+++ b/apple-nvram/src/lib.rs
@@ -49,7 +49,7 @@ pub enum Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum VarType {
     Common,
     System,
@@ -86,7 +86,7 @@ pub trait Nvram<'a> {
 
 pub trait Partition<'a>: Display {
     fn variables(&self) -> Box<dyn Iterator<Item = &dyn Variable<'a>> + '_>;
-    fn get_variable(&self, key: &'a [u8]) -> Option<&dyn Variable<'a>>;
+    fn get_variable(&self, key: &'a [u8], typ: VarType) -> Option<&dyn Variable<'a>>;
     fn insert_variable(&mut self, key: &'a [u8], value: Cow<'a, [u8]>, typ: VarType);
     fn remove_variable(&mut self, key: &'a [u8], typ: VarType);
 }

--- a/apple-nvram/src/lib.rs
+++ b/apple-nvram/src/lib.rs
@@ -49,7 +49,7 @@ pub enum Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum VarType {
     Common,
     System,

--- a/apple-nvram/src/lib.rs
+++ b/apple-nvram/src/lib.rs
@@ -73,6 +73,7 @@ pub fn nvram_parse<'a>(nvr: &'a [u8]) -> Result<Box<dyn Nvram<'a> + 'a>> {
 }
 
 pub trait NvramWriter {
+    fn erase_if_needed(&mut self, offset: u32, size: usize);
     fn write_all(&mut self, offset: u32, buf: &[u8]) -> std::io::Result<()>;
 }
 
@@ -81,7 +82,7 @@ pub trait Nvram<'a> {
     fn active_part_mut(&mut self) -> &mut dyn Partition<'a>;
     fn partitions(&self) -> Box<dyn Iterator<Item = &dyn Partition<'a>> + '_>;
     fn serialize(&self) -> Result<Vec<u8>>;
-    fn apply(&self, w: &mut dyn NvramWriter) -> Result<()>;
+    fn apply(&mut self, w: &mut dyn NvramWriter) -> Result<()>;
 }
 
 pub trait Partition<'a>: Display {

--- a/apple-nvram/src/lib.rs
+++ b/apple-nvram/src/lib.rs
@@ -98,7 +98,7 @@ impl<'a> Nvram<'a> {
         }
     }
 
-    pub fn serialize(&'a self) -> Result<Vec<u8>> {
+    pub fn serialize(&self) -> Result<Vec<u8>> {
         match self {
             Nvram::V1V2(nvram) => {
                 nvram.serialize()

--- a/apple-nvram/src/mtd.rs
+++ b/apple-nvram/src/mtd.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::File,
-    io::{Seek, Write},
+    io::{Seek, SeekFrom, Write},
     os::unix::io::AsRawFd,
 };
 
@@ -18,7 +18,7 @@ impl MtdWriter {
 
 impl NvramWriter for MtdWriter {
     fn write_all(&mut self, offset: u32, buf: &[u8]) -> std::io::Result<()> {
-        self.file.rewind()?;
+        self.file.seek(SeekFrom::Start(offset as u64))?;
         erase_if_needed_at(&self.file, offset, buf.len());
         self.file.write_all(buf)?;
 

--- a/apple-nvram/src/mtd.rs
+++ b/apple-nvram/src/mtd.rs
@@ -1,0 +1,65 @@
+use std::{
+    fs::File,
+    io::{Seek, Write},
+    os::unix::io::AsRawFd,
+};
+
+use crate::NvramWriter;
+
+pub struct MtdWriter {
+    file: File,
+}
+
+impl MtdWriter {
+    pub fn new(file: File) -> MtdWriter {
+        MtdWriter { file }
+    }
+}
+
+impl NvramWriter for MtdWriter {
+    fn write_all(&mut self, offset: u32, buf: &[u8]) -> std::io::Result<()> {
+        self.file.rewind()?;
+        erase_if_needed_at(&self.file, offset, buf.len());
+        self.file.write_all(buf)?;
+
+        Ok(())
+    }
+}
+
+#[repr(C)]
+pub struct EraseInfoUser {
+    start: u32,
+    length: u32,
+}
+
+#[repr(C)]
+#[derive(Default)]
+pub struct MtdInfoUser {
+    ty: u8,
+    flags: u32,
+    size: u32,
+    erasesize: u32,
+    writesize: u32,
+    oobsize: u32,
+    padding: u64,
+}
+
+nix::ioctl_write_ptr!(mtd_mem_erase, b'M', 2, EraseInfoUser);
+nix::ioctl_read!(mtd_mem_get_info, b'M', 1, MtdInfoUser);
+
+pub fn erase_if_needed(file: &File, size: usize) {
+    erase_if_needed_at(file, 0, size)
+}
+
+fn erase_if_needed_at(file: &File, offset: u32, size: usize) {
+    if unsafe { mtd_mem_get_info(file.as_raw_fd(), &mut MtdInfoUser::default()) }.is_err() {
+        return;
+    }
+    let erase_info = EraseInfoUser {
+        start: offset,
+        length: size as u32,
+    };
+    unsafe {
+        mtd_mem_erase(file.as_raw_fd(), &erase_info).unwrap();
+    }
+}

--- a/apple-nvram/src/v1v2.rs
+++ b/apple-nvram/src/v1v2.rs
@@ -131,7 +131,7 @@ impl<'a> Variable<'a> {
     }
 }
 
-impl<'a> Display for Variable<'a> {
+impl Display for Variable<'_> {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let key = String::from_utf8_lossy(self.key);
         let mut value = String::new();
@@ -324,6 +324,16 @@ impl<'a> Partition<'a> {
 
     pub fn variables(&self) -> impl Iterator<Item = &Variable<'a>> {
         self.common.values.values().chain(self.system.values.values())
+    }
+}
+
+impl Display for Partition<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f,
+            "size: {}, generation: {}, count: {}",
+            self.header.size, self.generation,
+            self.common.values.len() + self.system.values.len(),
+        )
     }
 }
 

--- a/apple-nvram/src/v1v2.rs
+++ b/apple-nvram/src/v1v2.rs
@@ -400,4 +400,10 @@ impl<'a> crate::Nvram<'a> for Nvram<'a> {
     fn partitions(&self) -> Box<dyn Iterator<Item = &dyn crate::Partition<'a>> + '_> {
         Box::new(self.partitions().map(|e| e as &dyn crate::Partition<'a>))
     }
+
+    fn apply(&self, w: &mut dyn crate::NvramWriter) -> Result<()> {
+        let data = self.serialize()?;
+        w.write_all(0, &data).map_err(|e| Error::ApplyError(e))?;
+        Ok(())
+    }
 }

--- a/apple-nvram/src/v1v2.rs
+++ b/apple-nvram/src/v1v2.rs
@@ -297,13 +297,18 @@ impl<'a> Partition<'a> {
 }
 
 impl<'a> crate::Partition<'a> for Partition<'a> {
-    fn get_variable(&self, key: &[u8]) -> Option<&dyn crate::Variable<'a>> {
-        match self.common.values.get(key) {
-            Some(v) => Some(v as &dyn crate::Variable<'a>),
-            None => match self.system.values.get(key) {
-                Some(v) => Some(v as &dyn crate::Variable<'a>),
-                None => None,
-            },
+    fn get_variable(&self, key: &[u8], typ: VarType) -> Option<&dyn crate::Variable<'a>> {
+        match typ {
+            VarType::Common => self
+                .common
+                .values
+                .get(key)
+                .map(|v| v as &dyn crate::Variable),
+            VarType::System => self
+                .system
+                .values
+                .get(key)
+                .map(|v| v as &dyn crate::Variable),
         }
     }
 

--- a/apple-nvram/src/v1v2.rs
+++ b/apple-nvram/src/v1v2.rs
@@ -1,0 +1,381 @@
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    fmt::{Debug, Formatter, Display},
+};
+
+use crate::{
+    VarType, Result, Error,
+    chrp_checksum_add,
+    slice_find,
+    slice_rstrip
+};
+
+pub struct UnescapeVal<I> {
+    inner: I,
+    esc_out: u8,
+    remaining: u8,
+}
+
+impl<I> UnescapeVal<I>
+where
+    I: Iterator<Item = u8>,
+{
+    pub fn new(inner: I) -> Self {
+        Self {
+            inner,
+            esc_out: 0,
+            remaining: 0,
+        }
+    }
+}
+
+impl<I> Iterator for UnescapeVal<I>
+where
+    I: Iterator<Item = u8>,
+{
+    type Item = u8;
+    fn next(&mut self) -> Option<u8> {
+        if self.remaining != 0 {
+            self.remaining -= 1;
+            return Some(self.esc_out);
+        }
+        if let Some(n) = self.inner.next() {
+            if n != 0xFF {
+                return Some(n);
+            }
+            let count = self.inner.next()?;
+            self.esc_out = if count & 0x80 == 0 { 0 } else { 0xFF };
+            self.remaining = (count & 0x7F) - 1;
+            Some(self.esc_out)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct CHRPHeader<'a> {
+    pub name: &'a [u8],
+    pub size: u16,
+    pub signature: u8,
+}
+
+impl Debug for CHRPHeader<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CHRPHeader")
+            .field("name", &String::from_utf8_lossy(self.name).into_owned())
+            .field("size", &self.size)
+            .field("signature", &self.signature)
+            .finish()
+    }
+}
+
+impl CHRPHeader<'_> {
+    pub fn parse(nvr: &[u8]) -> Result<CHRPHeader<'_>> {
+        let signature = nvr[0];
+        let cksum = nvr[1];
+        let size = u16::from_le_bytes(nvr[2..4].try_into().unwrap());
+        let name = slice_rstrip(&nvr[4..16], &0);
+        let cand = CHRPHeader {
+            name,
+            size,
+            signature,
+        };
+        if cand.checksum() != cksum {
+            return Err(Error::ParseError);
+        }
+        Ok(cand)
+    }
+    fn checksum(&self) -> u8 {
+        let mut cksum = 0;
+        for &u in self.name {
+            cksum = chrp_checksum_add(cksum, u);
+        }
+        cksum = chrp_checksum_add(cksum, self.signature);
+        cksum = chrp_checksum_add(cksum, (self.size & 0xFF) as u8);
+        chrp_checksum_add(cksum, (self.size >> 8) as u8)
+    }
+
+    pub fn serialize(&self, v: &mut Vec<u8>) {
+        v.push(self.signature);
+        v.push(self.checksum());
+        v.extend_from_slice(&self.size.to_le_bytes());
+        v.extend_from_slice(self.name);
+        for _ in 0..(12 - self.name.len()) {
+            v.push(0);
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Variable<'a> {
+    pub key: &'a [u8],
+    pub value: Cow<'a, [u8]>,
+    pub typ: VarType,
+}
+
+impl<'a> Variable<'a> {
+    pub fn new(key: &'a [u8], value: &'a [u8], typ: VarType) -> Variable<'a> {
+        Variable {
+            key,
+            value: Cow::Borrowed(value),
+            typ,
+        }
+    }
+
+    pub fn value(&self) -> Cow<'a, [u8]> {
+        Cow::Owned(UnescapeVal::new(
+            self.value.iter().copied()
+        ).collect())
+    }
+}
+
+impl<'a> Display for Variable<'a> {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        let key = String::from_utf8_lossy(self.key);
+        let mut value = String::new();
+        for c in UnescapeVal::new(self.value.iter().copied()) {
+            if (c as char).is_ascii() && !(c as char).is_ascii_control() {
+                value.push(c as char);
+            } else {
+                value.push_str(&format!("%{c:02x}"));
+            }
+        }
+
+        let value: String = value.chars().take(128).collect();
+        write!(f, "{}:{}={}", self.typ, key, value)
+    }
+}
+
+#[derive(Clone)]
+pub struct Section<'a> {
+    pub header: CHRPHeader<'a>,
+    pub values: HashMap<&'a [u8], Variable<'a>>,
+}
+
+impl Section<'_> {
+    pub fn parse(mut nvr: &[u8]) -> Result<Section<'_>> {
+        let header = CHRPHeader::parse(&nvr[..16])?;
+        nvr = &nvr[16..];
+        let mut values = HashMap::new();
+        loop {
+            let zero = slice_find(nvr, &0);
+            if zero.is_none() {
+                break;
+            }
+            let zero = zero.unwrap();
+            let cand = &nvr[..zero];
+            let eq = slice_find(cand, &b'=');
+            if eq.is_none() {
+                break;
+            }
+            let eq = eq.unwrap();
+            let key = &cand[..eq];
+            let typ = if header.name == b"common" {
+                VarType::Common
+            } else {
+                VarType::System
+            };
+            values.insert(key, Variable::new(key, &cand[(eq + 1)..], typ));
+            nvr = &nvr[(zero + 1)..]
+        }
+        Ok(Section { header, values })
+    }
+    fn size_bytes(&self) -> usize {
+        self.header.size as usize * 16
+    }
+    pub fn serialize(&self, v: &mut Vec<u8>) -> Result<()> {
+        let start_size = v.len();
+        self.header.serialize(v);
+        for val in self.values.values() {
+            v.extend_from_slice(val.key);
+            v.push(b'=');
+            v.extend_from_slice(&val.value);
+            v.push(0);
+        }
+        let my_size = v.len() - start_size;
+        if my_size > self.size_bytes() {
+            return Err(Error::SectionTooBig);
+        }
+        for _ in 0..(self.size_bytes() - my_size) {
+            v.push(0);
+        }
+        Ok(())
+    }
+}
+
+struct SectionDebug<'a, 'b>(&'a Section<'b>);
+impl Debug for SectionDebug<'_, '_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut m = f.debug_map();
+        for v in self.0.values.values() {
+            m.entry(
+                &String::from_utf8_lossy(v.key).into_owned(),
+                &String::from_utf8_lossy(
+                    &UnescapeVal::new(v.value.iter().copied()).collect::<Vec<_>>(),
+                )
+                .into_owned(),
+            );
+        }
+        m.finish()
+    }
+}
+
+impl Debug for Section<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Section")
+            .field("header", &self.header)
+            .field("values", &SectionDebug(self))
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Partition<'a> {
+    pub header: CHRPHeader<'a>,
+    pub generation: u32,
+    pub common: Section<'a>,
+    pub system: Section<'a>,
+}
+
+impl<'a> Partition<'a> {
+    pub fn parse(nvr: &[u8]) -> Result<Partition<'_>> {
+        let header = CHRPHeader::parse(&nvr[..16])?;
+        if header.name != b"nvram" {
+            return Err(Error::ParseError);
+        }
+        let adler = u32::from_le_bytes(nvr[16..20].try_into().unwrap());
+        let generation = u32::from_le_bytes(nvr[20..24].try_into().unwrap());
+        let sec1 = Section::parse(&nvr[32..])?;
+        let sec2 = Section::parse(&nvr[(32 + sec1.size_bytes())..])?;
+        let calc_adler =
+            adler32::adler32(&nvr[20..(32 + sec1.size_bytes() + sec2.size_bytes())]).unwrap();
+        if adler != calc_adler {
+            return Err(Error::ParseError);
+        }
+        let mut com = None;
+        let mut sys = None;
+        if sec1.header.name == b"common" {
+            com = Some(sec1);
+        } else if sec1.header.name == b"system" {
+            sys = Some(sec1);
+        }
+        if sec2.header.name == b"common" {
+            com = Some(sec2);
+        } else if sec2.header.name == b"system" {
+            sys = Some(sec2);
+        }
+        if com.is_none() || sys.is_none() {
+            return Err(Error::ParseError);
+        }
+        Ok(Partition {
+            header,
+            generation,
+            common: com.unwrap(),
+            system: sys.unwrap(),
+        })
+    }
+    fn size_bytes(&self) -> usize {
+        32 + self.common.size_bytes() + self.system.size_bytes()
+    }
+    pub fn serialize(&self, v: &mut Vec<u8>) -> Result<()> {
+        self.header.serialize(v);
+        v.extend_from_slice(&[0; 4]);
+        let adler_start = v.len();
+        v.extend_from_slice(&self.generation.to_le_bytes());
+        v.extend_from_slice(&[0; 8]);
+        self.common.serialize(v)?;
+        self.system.serialize(v)?;
+        let adler_end = v.len();
+        let adler = adler32::adler32(&v[adler_start..adler_end]).unwrap();
+        v[(adler_start - 4)..adler_start].copy_from_slice(&adler.to_le_bytes());
+        Ok(())
+    }
+
+    pub fn get_variable(&self, key: &[u8]) -> Option<&Variable<'a>> {
+        match self.common.values.get(key) {
+            Some(v) => Some(v),
+            None => self.system.values.get(key),
+        }
+    }
+
+    pub fn insert_variable(&mut self, key: &'a [u8], value: Cow<'a, [u8]>, typ: VarType) {
+        match typ {
+            VarType::Common => {
+                &mut self.common
+            },
+            VarType::System => {
+                &mut self.system
+            }
+        }.values.insert(key, Variable { key, value, typ });
+    }
+
+    pub fn remove_variable(&mut self, key: &'a [u8], typ: VarType) {
+        match typ {
+            VarType::Common => {
+                &mut self.common
+            },
+            VarType::System => {
+                &mut self.system
+            }
+        }.values.remove(key);
+    }
+
+    pub fn variables(&self) -> impl Iterator<Item = &Variable<'a>> {
+        self.common.values.values().chain(self.system.values.values())
+    }
+}
+
+#[derive(Debug)]
+pub struct Nvram<'a> {
+    pub partitions: [Partition<'a>; 2],
+    pub active: usize,
+}
+
+impl<'a> Nvram<'a> {
+    pub fn parse(nvr: &[u8]) -> Result<Nvram<'_>> {
+        let p1;
+        let p2;
+        match (Partition::parse(nvr), Partition::parse(&nvr[0x10000..])) {
+            (Err(err), Err(_)) => return Err(err),
+            (Ok(p1r), Err(_)) => {
+                p1 = p1r;
+                p2 = p1.clone();
+            }
+            (Err(_), Ok(p2r)) => {
+                p2 = p2r;
+                p1 = p2.clone();
+            }
+            (Ok(p1r), Ok(p2r)) => {
+                p1 = p1r;
+                p2 = p2r;
+            }
+        }
+        let active = if p1.generation > p2.generation { 0 } else { 1 };
+        let partitions = [p1, p2];
+        Ok(Nvram { partitions, active })
+    }
+    pub fn serialize(&self) -> Result<Vec<u8>> {
+        let mut v = Vec::with_capacity(self.partitions[0].size_bytes() * 2);
+        self.partitions[0].serialize(&mut v)?;
+        self.partitions[1].serialize(&mut v)?;
+        Ok(v)
+    }
+    pub fn prepare_for_write(&mut self) {
+        let inactive = 1 - self.active;
+        self.partitions[inactive] = self.partitions[self.active].clone();
+        self.partitions[inactive].generation += 1;
+        self.active = inactive;
+    }
+    // pub fn active_part(&self) -> &Partition<'a> {
+    //     &self.partitions[self.active]
+    // }
+    pub fn active_part_mut(&mut self) -> &mut Partition<'a> {
+        &mut self.partitions[self.active]
+    }
+
+    pub fn partitions(&self) -> impl Iterator<Item = &Partition<'a>> {
+        self.partitions.iter()
+    }
+}

--- a/apple-nvram/src/v1v2.rs
+++ b/apple-nvram/src/v1v2.rs
@@ -406,8 +406,9 @@ impl<'a> crate::Nvram<'a> for Nvram<'a> {
         Box::new(self.partitions().map(|e| e as &dyn crate::Partition<'a>))
     }
 
-    fn apply(&self, w: &mut dyn crate::NvramWriter) -> Result<()> {
+    fn apply(&mut self, w: &mut dyn crate::NvramWriter) -> Result<()> {
         let data = self.serialize()?;
+        w.erase_if_needed(0, data.len());
         w.write_all(0, &data).map_err(|e| Error::ApplyError(e))?;
         Ok(())
     }

--- a/apple-nvram/src/v1v2.rs
+++ b/apple-nvram/src/v1v2.rs
@@ -1,15 +1,10 @@
 use std::{
     borrow::Cow,
     collections::HashMap,
-    fmt::{Debug, Formatter, Display},
+    fmt::{Debug, Display, Formatter},
 };
 
-use crate::{
-    VarType, Result, Error,
-    chrp_checksum_add,
-    slice_find,
-    slice_rstrip
-};
+use crate::{chrp_checksum_add, slice_find, slice_rstrip, Error, Result, VarType};
 
 pub struct UnescapeVal<I> {
     inner: I,
@@ -125,9 +120,7 @@ impl<'a> Variable<'a> {
     }
 
     pub fn value(&self) -> Cow<'a, [u8]> {
-        Cow::Owned(UnescapeVal::new(
-            self.value.iter().copied()
-        ).collect())
+        Cow::Owned(UnescapeVal::new(self.value.iter().copied()).collect())
     }
 }
 
@@ -302,36 +295,37 @@ impl<'a> Partition<'a> {
 
     pub fn insert_variable(&mut self, key: &'a [u8], value: Cow<'a, [u8]>, typ: VarType) {
         match typ {
-            VarType::Common => {
-                &mut self.common
-            },
-            VarType::System => {
-                &mut self.system
-            }
-        }.values.insert(key, Variable { key, value, typ });
+            VarType::Common => &mut self.common,
+            VarType::System => &mut self.system,
+        }
+        .values
+        .insert(key, Variable { key, value, typ });
     }
 
     pub fn remove_variable(&mut self, key: &'a [u8], typ: VarType) {
         match typ {
-            VarType::Common => {
-                &mut self.common
-            },
-            VarType::System => {
-                &mut self.system
-            }
-        }.values.remove(key);
+            VarType::Common => &mut self.common,
+            VarType::System => &mut self.system,
+        }
+        .values
+        .remove(key);
     }
 
     pub fn variables(&self) -> impl Iterator<Item = &Variable<'a>> {
-        self.common.values.values().chain(self.system.values.values())
+        self.common
+            .values
+            .values()
+            .chain(self.system.values.values())
     }
 }
 
 impl Display for Partition<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f,
+        write!(
+            f,
             "size: {}, generation: {}, count: {}",
-            self.header.size, self.generation,
+            self.header.size,
+            self.generation,
             self.common.values.len() + self.system.values.len(),
         )
     }

--- a/apple-nvram/src/v3.rs
+++ b/apple-nvram/src/v3.rs
@@ -247,7 +247,12 @@ impl<'a> Partition<'a> {
                     break;
                 }
 
-                let v_header = VarHeader::parse(&nvr[offset..])?;
+                let Ok(v_header) = VarHeader::parse(&nvr[offset..]) else {
+                    // if there's no valid header, just end here and return values parsed so far
+                    // we also know there is no space for adding any new or updated variables
+                    empty_region_end = offset;
+                    break;
+                };
 
                 let k_begin = offset + VAR_HEADER_SIZE;
                 let k_end = k_begin + v_header.name_size as usize;

--- a/apple-nvram/src/v3.rs
+++ b/apple-nvram/src/v3.rs
@@ -417,8 +417,11 @@ impl Display for Partition<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "size: {}, generation: {}, state: 0x{:02x}, flags: 0x{:02x}, count: {}",
+            "size: {}, total_used: {}, system_used: {}, common_used: {}, generation: 0x{:02x}, state: 0x{:02x}, flags: 0x{:02x}, count: {}",
             self.header.size,
+            self.total_used(),
+            self.system_used(),
+            self.common_used(),
             self.generation(),
             self.header.state,
             self.header.flags,

--- a/apple-nvram/src/v3.rs
+++ b/apple-nvram/src/v3.rs
@@ -171,6 +171,10 @@ impl<'a> crate::Nvram<'a> for Nvram<'a> {
                     .clone_active(),
             );
             self.active = new_active;
+            // we could still have too many active variables
+            if self.active_part().total_size() > PARTITION_SIZE {
+                return Err(Error::SectionTooBig);
+            }
         }
 
         let mut data = Vec::with_capacity(PARTITION_SIZE);

--- a/apple-nvram/src/v3.rs
+++ b/apple-nvram/src/v3.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, fmt};
 use indexmap::IndexMap;
 
-use super::{Result, Error};
+use super::{VarType, Result, Error};
 
 // https://github.com/apple-oss-distributions/xnu/blob/main/iokit/Kernel/IONVRAMV3Handler.cpp#L630
 
@@ -207,19 +207,6 @@ impl<'a> fmt::Display for Variable<'a> {
         let value: String = value.chars().take(128).collect();
         write!(f, "{}:{}={} (state:0x{:02x})",
             self.typ(), key, value, self.header.state)
-    }
-}
-
-pub enum VarType {
-    Common, System
-}
-
-impl fmt::Display for VarType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            &VarType::Common => write!(f, "common"),
-            &VarType::System => write!(f, "system"),
-        }
     }
 }
 

--- a/apple-nvram/src/v3.rs
+++ b/apple-nvram/src/v3.rs
@@ -118,11 +118,14 @@ impl<'a> Nvram<'a> {
     }
 
     fn partitions(&self) -> impl Iterator<Item = &Partition<'a>> {
-        self.partitions.iter().filter_map(|x| match x {
-            Slot::Valid(p) => Some(p),
-            Slot::Invalid => None,
-            Slot::Empty => None,
-        })
+        self.partitions
+            .iter()
+            .take(self.partition_count)
+            .filter_map(|x| match x {
+                Slot::Valid(p) => Some(p),
+                Slot::Invalid => None,
+                Slot::Empty => None,
+            })
     }
 
     fn active_part(&self) -> &Partition<'a> {

--- a/apple-nvram/src/v3.rs
+++ b/apple-nvram/src/v3.rs
@@ -147,10 +147,7 @@ impl<'a> Partition<'a> {
                     };
 
                     offset += v.size();
-                    // println!("DEBUG 0x{:04x} {}", offset, &v);
-                    // if v.header.state == VAR_ADDED {
                     values.push((key, v));
-                    // }
                 }
                 _ => {
                     offset += VAR_HEADER_SIZE;

--- a/apple-nvram/src/v3.rs
+++ b/apple-nvram/src/v3.rs
@@ -318,6 +318,9 @@ impl<'a> Variable<'a> {
     fn serialize(&self, v: &mut [u8]) {
         match self.offset {
             Some(offset) => {
+                // TODO: this doesn't work when we replace
+                // a variable with one that has different size
+                // because there can't be any gaps or overlaps
                 self.header.serialize(&mut v[offset..]);
                 let k_begin = offset + VAR_HEADER_SIZE;
                 let k_end = k_begin + self.key.len();

--- a/apple-nvram/src/v3.rs
+++ b/apple-nvram/src/v3.rs
@@ -200,7 +200,7 @@ impl<'a> Partition<'a> {
     }
 
     fn total_size(&self) -> usize {
-        self.values.iter().fold(0, |acc, v| acc + v.1.size())
+        STORE_HEADER_SIZE + self.values.iter().fold(0, |acc, v| acc + v.1.size())
     }
 
     fn serialize(&self, v: &mut Vec<u8>) {
@@ -210,6 +210,7 @@ impl<'a> Partition<'a> {
             var.serialize(v);
         }
         let my_size = v.len() - start_size;
+        debug_assert!(v.len() == self.total_size());
 
         // padding
         for _ in 0..(self.header.size() - my_size) {

--- a/apple-nvram/src/v3.rs
+++ b/apple-nvram/src/v3.rs
@@ -201,9 +201,9 @@ impl<'a> Partition<'a> {
 }
 
 impl<'a> crate::Partition<'a> for Partition<'a> {
-    fn get_variable(&self, key: &[u8]) -> Option<&dyn crate::Variable<'a>> {
+    fn get_variable(&self, key: &[u8], typ: VarType) -> Option<&dyn crate::Variable<'a>> {
         self.values.iter().find_map(|e| {
-            if e.0 == key && e.1.header.state == VAR_ADDED {
+            if e.0 == key && e.1.typ() == typ && e.1.header.state == VAR_ADDED {
                 Some(&e.1 as &dyn crate::Variable<'a>)
             } else {
                 None

--- a/apple-nvram/src/v3.rs
+++ b/apple-nvram/src/v3.rs
@@ -1,0 +1,214 @@
+use std::{borrow::Cow, collections::HashMap, fmt};
+use super::{Result, Error};
+
+// https://github.com/apple-oss-distributions/xnu/blob/main/iokit/Kernel/IONVRAMV3Handler.cpp#L630
+
+const VARIABLE_STORE_SIGNATURE: &[u8; 4] = b"3VVN";
+const VARIABLE_STORE_VERSION: u8 = 0x1;
+const VARIABLE_DATA: u16 = 0x55AA;
+
+const STORE_HEADER_SIZE: usize = 24;
+const VAR_HEADER_SIZE: usize = 36;
+
+const APPLE_SYSTEM_VARIABLE_GUID: &[u8; 16] = &[0x40, 0xA0, 0xDD, 0xD2, 0x77, 0xF8, 0x43, 0x92, 0xB4, 0xA3, 0x1E, 0x73, 0x04, 0x20, 0x65, 0x16];
+
+#[derive(Debug)]
+pub struct Nvram<'a> {
+    pub partitions: [Partition<'a>; 2],
+    pub active: usize,
+}
+
+impl<'a> Nvram<'a> {
+    pub fn parse(nvr: &[u8]) -> Result<Nvram<'_>> {
+        let p1;
+        let p2;
+        match (Partition::parse(nvr), Partition::parse(&nvr[0x10000..])) {
+            (Err(err), Err(_)) => return Err(err),
+            (Ok(p1r), Err(_)) => {
+                p1 = p1r;
+                p2 = p1.clone();
+            }
+            (Err(_), Ok(p2r)) => {
+                p2 = p2r;
+                p1 = p2.clone();
+            }
+            (Ok(p1r), Ok(p2r)) => {
+                p1 = p1r;
+                p2 = p2r;
+            }
+        }
+        let active = if p1.generation() > p2.generation() { 0 } else { 1 };
+        let partitions = [p1, p2];
+        Ok(Nvram { partitions, active })
+    }
+
+    pub fn active_part_mut(&mut self) -> &mut Partition<'a> {
+        &mut self.partitions[self.active]
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Partition<'a> {
+    pub header: StoreHeader<'a>,
+    pub values: HashMap<&'a [u8], Variable<'a>>,
+}
+
+impl<'a> Partition<'a> {
+    pub fn parse(nvr: &[u8]) -> Result<Partition<'_>> {
+        let header = StoreHeader::parse(&nvr[..STORE_HEADER_SIZE])?;
+        let mut offset = STORE_HEADER_SIZE;
+        let mut values = HashMap::new();
+
+        while offset + VAR_HEADER_SIZE < header.size() {
+            let mut empty = true;
+            for i in 0..VAR_HEADER_SIZE {
+                if nvr[offset + i] != 0 && nvr[offset + i] != 0xFF {
+                    empty = false;
+                    break;
+                }
+            }
+            if empty {
+                break
+            }
+
+            if let Ok(v_header) = VarHeader::parse(&nvr[offset..]) {
+                let k_begin = offset + VAR_HEADER_SIZE;
+                let k_end = k_begin + v_header.name_size as usize;
+                let key = &nvr[k_begin..k_end - 1];
+
+                let v_begin = k_end;
+                let v_end = k_end + v_header.data_size as usize;
+                let value = &nvr[v_begin..v_end];
+                let v = Variable {
+                    header: v_header, key,
+                    value: Cow::Borrowed(value),
+                };
+
+                offset += v.size();
+                values.insert(key, v);
+            } else {
+                offset += VAR_HEADER_SIZE;
+            }
+        }
+
+        Ok(Partition { header, values })
+    }
+
+    pub fn generation(&self) -> u32 {
+        self.header.generation
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StoreHeader<'a> {
+    pub name: &'a [u8],
+    pub size: u32,
+    pub generation: u32,
+    pub state: u8,
+    pub flags: u8,
+    pub version: u8,
+    pub system_size: u32,
+    pub common_size: u32,
+}
+
+impl<'a> StoreHeader<'a> {
+    pub fn parse(nvr: &[u8]) -> Result<StoreHeader<'_>> {
+        let name = &nvr[..4];
+        let size = u32::from_le_bytes(nvr[4..8].try_into().unwrap());
+        let generation = u32::from_le_bytes(nvr[8..12].try_into().unwrap());
+        let state = nvr[12];
+        let flags = nvr[13];
+        let version = nvr[14];
+        let system_size = u32::from_le_bytes(nvr[16..20].try_into().unwrap());
+        let common_size = u32::from_le_bytes(nvr[20..24].try_into().unwrap());
+
+        if name != VARIABLE_STORE_SIGNATURE {
+            return Err(Error::ParseError);
+        }
+        if version != VARIABLE_STORE_VERSION {
+            return Err(Error::ParseError);
+        }
+
+        Ok(StoreHeader {
+            name, size,
+            generation, state,
+            flags, version,
+            system_size, common_size,
+        })
+    }
+
+    pub fn size(&self) -> usize {
+        self.size as usize
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Variable<'a> {
+    pub header: VarHeader<'a>,
+    pub key: &'a [u8],
+    pub value: Cow<'a, [u8]>,
+}
+
+impl<'a> Variable<'a> {
+    pub fn size(&self) -> usize {
+        (self.header.name_size + self.header.data_size) as usize
+    }
+
+    pub fn typ(&self) -> VarType {
+        if self.header.guid == APPLE_SYSTEM_VARIABLE_GUID {
+            return VarType::System;
+        }
+        VarType::Common
+    }
+}
+
+impl<'a> fmt::Display for Variable<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let key = String::from_utf8_lossy(self.key);
+        let value = String::from_utf8_lossy(&self.value);
+        write!(f, "{}:{}={}", self.typ(), key, value)
+    }
+}
+
+pub enum VarType {
+    Common, System
+}
+
+impl fmt::Display for VarType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            &VarType::Common => write!(f, "common"),
+            &VarType::System => write!(f, "system"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct VarHeader<'a> {
+    pub state: u8,
+    pub attrs: u32,
+    pub name_size: u32,
+    pub data_size: u32,
+    pub guid: &'a [u8],
+}
+
+impl<'a> VarHeader<'a> {
+    pub fn parse(nvr: &[u8]) -> Result<VarHeader<'_>> {
+        let start_id = u16::from_le_bytes(nvr[..2].try_into().unwrap());
+        if start_id != VARIABLE_DATA {
+            return Err(Error::ParseError);
+        }
+        let state = nvr[2];
+        let attrs = u32::from_le_bytes(nvr[4..8].try_into().unwrap());
+        let name_size = u32::from_le_bytes(nvr[8..12].try_into().unwrap());
+        let data_size = u32::from_le_bytes(nvr[12..16].try_into().unwrap());
+        let guid = &nvr[16..32];
+        let _crc = u32::from_le_bytes(nvr[32..36].try_into().unwrap());
+
+        if VAR_HEADER_SIZE + (name_size + data_size) as usize > nvr.len() {
+            return Err(Error::ParseError);
+        }
+
+        Ok(VarHeader { state, attrs, name_size, data_size, guid })
+    }
+}

--- a/apple-nvram/src/v3.rs
+++ b/apple-nvram/src/v3.rs
@@ -144,7 +144,6 @@ impl<'a> Partition<'a> {
                         header: v_header,
                         key,
                         value: Cow::Borrowed(value),
-                        offset: Some(offset),
                     };
 
                     offset += v.size();
@@ -324,7 +323,6 @@ pub struct Variable<'a> {
     pub header: VarHeader<'a>,
     pub key: &'a [u8],
     pub value: Cow<'a, [u8]>,
-    offset: Option<usize>,
 }
 
 impl<'a> Variable<'a> {
@@ -368,9 +366,8 @@ impl Display for Variable<'_> {
         let value: String = value.chars().take(128).collect();
         write!(
             f,
-            "(s:0x{:02x} o:0x{:05x}) {}:{}={}",
+            "(s:0x{:02x}) {}:{}={}",
             self.header.state,
-            self.offset.unwrap_or_default(),
             self.typ(),
             key,
             value

--- a/apple-nvram/src/v3.rs
+++ b/apple-nvram/src/v3.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt};
+use std::{borrow::Cow, fmt::{Formatter, Display}};
 use indexmap::IndexMap;
 
 use crate::{VarType, Result, Error};
@@ -165,6 +165,16 @@ impl<'a> Partition<'a> {
     }
 }
 
+impl Display for Partition<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f,
+            "size: {}, generation: {}, state: 0x{:02x}, flags: 0x{:02x}, count: {}",
+            self.header.size, self.generation(), self.header.state,
+            self.header.flags, self.values.len()
+        )
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct StoreHeader<'a> {
     pub name: &'a [u8],
@@ -232,8 +242,8 @@ impl<'a> Variable<'a> {
     }
 }
 
-impl<'a> fmt::Display for Variable<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl<'a> Display for Variable<'a> {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let key = String::from_utf8_lossy(self.key);
         let mut value = String::new();
         for c in self.value.iter().copied() {

--- a/asahi-bless/src/main.rs
+++ b/asahi-bless/src/main.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 #![allow(dead_code)]
-use gpt::{disk::LogicalBlockSize, GptConfig};
 use apple_nvram::{erase_if_needed, Nvram, VarType};
+use gpt::{disk::LogicalBlockSize, GptConfig};
 use std::{
     borrow::Cow,
     collections::HashMap,
+    env,
     fs::{File, OpenOptions},
     io::{stdin, stdout, Read, Seek, SeekFrom, Write},
-    env
 };
 use uuid::Uuid;
 

--- a/asahi-bless/src/main.rs
+++ b/asahi-bless/src/main.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #![allow(dead_code)]
 use gpt::{disk::LogicalBlockSize, GptConfig};
-use apple_nvram::{erase_if_needed, Nvram, Variable, VarType};
+use apple_nvram::{erase_if_needed, Nvram, VarType};
 use std::{
     borrow::Cow,
     collections::HashMap,
@@ -296,13 +296,10 @@ fn main() {
     file.read_to_end(&mut data).unwrap();
     let mut nv = Nvram::parse(&data).unwrap();
     nv.prepare_for_write();
-    nv.active_part_mut().system.values.insert(
+    nv.active_part_mut().insert_variable(
         nvram_key,
-        Variable {
-            key: nvram_key,
-            value: Cow::Owned(boot_str.into_bytes()),
-            typ: VarType::System,
-        }
+        Cow::Owned(boot_str.into_bytes()),
+        VarType::System,
     );
     file.rewind().unwrap();
     let data = nv.serialize().unwrap();

--- a/asahi-bless/src/main.rs
+++ b/asahi-bless/src/main.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 #![allow(dead_code)]
-use apple_nvram::{erase_if_needed, Nvram, VarType};
+use apple_nvram::{erase_if_needed, nvram_parse, VarType};
 use gpt::{disk::LogicalBlockSize, GptConfig};
 use std::{
     borrow::Cow,
@@ -294,7 +294,7 @@ fn main() {
         .unwrap();
     let mut data = Vec::new();
     file.read_to_end(&mut data).unwrap();
-    let mut nv = Nvram::parse(&data).unwrap();
+    let mut nv = nvram_parse(&data).unwrap();
     nv.prepare_for_write();
     nv.active_part_mut().insert_variable(
         nvram_key,

--- a/asahi-bless/src/main.rs
+++ b/asahi-bless/src/main.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 #![allow(dead_code)]
 use gpt::{disk::LogicalBlockSize, GptConfig};
-use apple_nvram::{erase_if_needed, Nvram, Variable};
+use apple_nvram::{erase_if_needed, Nvram, Variable, VarType};
 use std::{
     borrow::Cow,
     collections::HashMap,
@@ -300,7 +300,8 @@ fn main() {
         nvram_key,
         Variable {
             key: nvram_key,
-            value: Cow::Owned(boot_str.into_bytes())
+            value: Cow::Owned(boot_str.into_bytes()),
+            typ: VarType::System,
         }
     );
     file.rewind().unwrap();

--- a/asahi-btsync/src/main.rs
+++ b/asahi-btsync/src/main.rs
@@ -17,6 +17,7 @@ use ini::Ini;
 enum Error {
     Parse,
     SectionTooBig,
+    ApplyError(std::io::Error),
     VariableNotFound,
     FileIO,
     BluezConfigDirNotFound,
@@ -28,6 +29,7 @@ impl From<apple_nvram::Error> for Error {
         match e {
             apple_nvram::Error::ParseError => Error::Parse,
             apple_nvram::Error::SectionTooBig => Error::SectionTooBig,
+            apple_nvram::Error::ApplyError(e) => Error::ApplyError(e),
         }
     }
 }

--- a/asahi-btsync/src/main.rs
+++ b/asahi-btsync/src/main.rs
@@ -9,7 +9,7 @@ use std::{
     path::Path,
 };
 
-use apple_nvram::{nvram_parse, Variable};
+use apple_nvram::{nvram_parse, VarType, Variable};
 
 use ini::Ini;
 
@@ -80,7 +80,7 @@ fn real_main() -> Result<()> {
     let mut nv = nvram_parse(&data)?;
     let active = nv.active_part_mut();
     let bt_devs = active
-        .get_variable(bt_var.as_bytes())
+        .get_variable(bt_var.as_bytes(), VarType::System)
         .ok_or(Error::VariableNotFound)?;
 
     match matches.subcommand() {

--- a/asahi-nvram/src/main.rs
+++ b/asahi-nvram/src/main.rs
@@ -35,95 +35,6 @@ fn main() -> Result<()> {
     real_main()
 }
 
-// fn real_v3_main() -> Result<()> {
-//     let matches = clap::command!()
-//         .arg(clap::arg!(-d --device [DEVICE] "Path to the nvram device."))
-//         .subcommand(
-//             clap::Command::new("read")
-//                 .about("Read nvram variables")
-//                 .arg(clap::Arg::new("variable").multiple_values(true)),
-//         )
-//         .subcommand(
-//             clap::Command::new("delete")
-//                 .about("Delete nvram variables")
-//                 .arg(clap::Arg::new("variable").multiple_values(true)),
-//         )
-//         .subcommand(
-//             clap::Command::new("write")
-//                 .about("Write nvram variables")
-//                 .arg(clap::Arg::new("variable=value").multiple_values(true)),
-//         )
-//         .get_matches();
-//     let default_name = "/dev/mtd0".to_owned();
-//     let mut file = OpenOptions::new()
-//         .read(true)
-//         .write(true)
-//         .open(matches.get_one::<String>("device").unwrap_or(&default_name))
-//         .unwrap();
-//     let mut data = Vec::new();
-//     file.read_to_end(&mut data).unwrap();
-//     let mut nv = v3::Nvram::parse(&data)?;
-//     match matches.subcommand() {
-//         Some(("read", args)) => {
-//             let vars = args.get_many::<String>("variable");
-//             if let Some(vars) = vars {
-//                 for var in vars {
-//                     let (_, name) = var.split_once(':').ok_or(Error::MissingPartitionName)?;
-//                     let part = nv.active_part_mut();
-//                     let v = part
-//                         .values
-//                         .get(name.as_bytes())
-//                         .ok_or(Error::VariableNotFound)?;
-//                     println!("{}", v);
-//                 }
-//             } else {
-//                 for part in nv.partitions() {
-//                     println!("size: {}, generation: {}, state: 0x{:02x}, flags: 0x{:02x}, count: {}",
-//                              part.header.size, part.generation(), part.header.state,
-//                              part.header.flags, part.values.len());
-//                     for var in part.values.values() {
-//                         println!("{}", var);
-//                     }
-//                     println!("========================================================")
-//                 }
-//             }
-//         }
-//         // Some(("write", args)) => {
-//         //     let vars = args.get_many::<String>("variable=value");
-//         //     nv.prepare_for_write();
-//         //     for var in vars.unwrap_or_default() {
-//         //         let (key, value) = var.split_once('=').ok_or(Error::MissingValue)?;
-//         //         let (part, name) = key.split_once(':').ok_or(Error::MissingPartitionName)?;
-//         //         part_by_name(part, &mut nv)?.values.insert(
-//         //             name.as_bytes(),
-//         //             Variable {
-//         //                 key: name.as_bytes(),
-//         //                 value: Cow::Owned(read_var(value)?),
-//         //             },
-//         //         );
-//         //     }
-//         //     file.rewind().unwrap();
-//         //     let data = nv.serialize()?;
-//         //     erase_if_needed(&file, data.len());
-//         //     file.write_all(&data).unwrap();
-//         // }
-//         // Some(("delete", args)) => {
-//         //     let vars = args.get_many::<String>("variable");
-//         //     nv.prepare_for_write();
-//         //     for var in vars.unwrap_or_default() {
-//         //         let (part, name) = var.split_once(':').ok_or(Error::MissingPartitionName)?;
-//         //         part_by_name(part, &mut nv)?.values.remove(name.as_bytes());
-//         //     }
-//         //     file.rewind().unwrap();
-//         //     let data = nv.serialize()?;
-//         //     erase_if_needed(&file, data.len());
-//         //     file.write_all(&data).unwrap();
-//         // }
-//         _ => {}
-//     }
-//     Ok(())
-// }
-
 fn real_main() -> Result<()> {
     let matches = clap::command!()
         .arg(clap::arg!(-d --device [DEVICE] "Path to the nvram device."))
@@ -165,16 +76,16 @@ fn real_main() -> Result<()> {
                     println!("{}", v);
                 }
             } else {
-                for var in active.variables() {
-                    println!("{}", var);
-                }
-                // for part in nv.partitions() {
-                //     println!("{}", part);
-                //     for var in part.variables() {
-                //         println!("{}", var);
-                //     }
-                //     println!("========================================================")
+                // for var in active.variables() {
+                //     println!("{}", var);
                 // }
+                for part in nv.partitions() {
+                    println!("{}", part);
+                    for var in part.variables() {
+                        println!("{}", var);
+                    }
+                    println!("========================================================")
+                }
             }
         }
         Some(("write", args)) => {

--- a/asahi-nvram/src/main.rs
+++ b/asahi-nvram/src/main.rs
@@ -72,16 +72,15 @@ fn real_v3_main() -> Result<()> {
             if let Some(vars) = vars {
                 for var in vars {
                     let (_, name) = var.split_once(':').ok_or(Error::MissingPartitionName)?;
-                    for part in &nv.partitions {
-                        let v = part
-                            .values
-                            .get(name.as_bytes())
-                            .ok_or(Error::VariableNotFound)?;
-                        println!("{}", v);
-                    }
+                    let part = nv.active_part();
+                    let v = part
+                        .values
+                        .get(name.as_bytes())
+                        .ok_or(Error::VariableNotFound)?;
+                    println!("{}", v);
                 }
             } else {
-                for part in &nv.partitions {
+                for part in nv.partitions() {
                     println!("size: {}, generation: {}, state: 0x{:02x}, flags: 0x{:02x}, count: {}",
                              part.header.size, part.generation(), part.header.state,
                              part.header.flags, part.values.len());

--- a/asahi-nvram/src/main.rs
+++ b/asahi-nvram/src/main.rs
@@ -71,9 +71,10 @@ fn real_main() -> Result<()> {
             let vars = args.get_many::<String>("variable");
             if let Some(vars) = vars {
                 for var in vars {
-                    let (_part, name) = var.split_once(':').ok_or(Error::MissingPartitionName)?;
+                    let (part, name) = var.split_once(':').ok_or(Error::MissingPartitionName)?;
+                    let typ = part_by_name(part)?;
                     let v = active
-                        .get_variable(name.as_bytes())
+                        .get_variable(name.as_bytes(), typ)
                         .ok_or(Error::VariableNotFound)?;
                     println!("{}", v);
                 }

--- a/asahi-nvram/src/main.rs
+++ b/asahi-nvram/src/main.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-use std::{borrow::Cow, fs::OpenOptions, io::Read};
+use std::{borrow::Cow, fs::OpenOptions, io::Read, process::ExitCode};
 
 use apple_nvram::{mtd::MtdWriter, nvram_parse, VarType};
 
@@ -27,8 +27,14 @@ impl From<apple_nvram::Error> for Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
-fn main() {
-    real_main().unwrap()
+fn main() -> ExitCode {
+    match real_main() {
+        Ok(_) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("{:?}", e);
+            ExitCode::FAILURE
+        }
+    }
 }
 
 fn real_main() -> Result<()> {

--- a/asahi-nvram/src/main.rs
+++ b/asahi-nvram/src/main.rs
@@ -68,6 +68,8 @@ fn real_main() -> Result<()> {
     match matches.subcommand() {
         Some(("read", args)) => {
             let active = nv.active_part_mut();
+            // println!("stats: {}", active);
+
             let vars = args.get_many::<String>("variable");
             if let Some(vars) = vars {
                 for var in vars {

--- a/asahi-nvram/src/main.rs
+++ b/asahi-nvram/src/main.rs
@@ -96,11 +96,7 @@ fn real_main() -> Result<()> {
                 let (key, value) = var.split_once('=').ok_or(Error::MissingValue)?;
                 let (part, name) = key.split_once(':').ok_or(Error::MissingPartitionName)?;
                 let typ = part_by_name(part)?;
-                active.insert_variable(
-                    name.as_bytes(),
-                    Cow::Owned(read_var(value)?),
-                    typ,
-                );
+                active.insert_variable(name.as_bytes(), Cow::Owned(read_var(value)?), typ);
             }
             file.rewind().unwrap();
             let data = nv.serialize()?;

--- a/asahi-nvram/src/main.rs
+++ b/asahi-nvram/src/main.rs
@@ -13,6 +13,7 @@ use apple_nvram::{erase_if_needed, nvram_parse, VarType};
 enum Error {
     Parse,
     SectionTooBig,
+    ApplyError(std::io::Error),
     MissingPartitionName,
     MissingValue,
     VariableNotFound,
@@ -25,6 +26,7 @@ impl From<apple_nvram::Error> for Error {
         match e {
             apple_nvram::Error::ParseError => Error::Parse,
             apple_nvram::Error::SectionTooBig => Error::SectionTooBig,
+            apple_nvram::Error::ApplyError(e) => Error::ApplyError(e),
         }
     }
 }

--- a/asahi-nvram/src/main.rs
+++ b/asahi-nvram/src/main.rs
@@ -7,7 +7,7 @@ use std::{
     io::{Read, Seek, Write},
 };
 
-use apple_nvram::{erase_if_needed, Nvram, VarType};
+use apple_nvram::{erase_if_needed, nvram_parse, VarType};
 
 #[derive(Debug)]
 enum Error {
@@ -62,7 +62,7 @@ fn real_main() -> Result<()> {
         .unwrap();
     let mut data = Vec::new();
     file.read_to_end(&mut data).unwrap();
-    let mut nv = Nvram::parse(&data)?;
+    let mut nv = nvram_parse(&data)?;
     match matches.subcommand() {
         Some(("read", args)) => {
             let active = nv.active_part_mut();
@@ -91,7 +91,7 @@ fn real_main() -> Result<()> {
         Some(("write", args)) => {
             let vars = args.get_many::<String>("variable=value");
             nv.prepare_for_write();
-            let mut active = nv.active_part_mut();
+            let active = nv.active_part_mut();
             for var in vars.unwrap_or_default() {
                 let (key, value) = var.split_once('=').ok_or(Error::MissingValue)?;
                 let (part, name) = key.split_once(':').ok_or(Error::MissingPartitionName)?;
@@ -106,7 +106,7 @@ fn real_main() -> Result<()> {
         Some(("delete", args)) => {
             let vars = args.get_many::<String>("variable");
             nv.prepare_for_write();
-            let mut active = nv.active_part_mut();
+            let active = nv.active_part_mut();
             for var in vars.unwrap_or_default() {
                 let (part, name) = var.split_once(':').ok_or(Error::MissingPartitionName)?;
                 let typ = part_by_name(part)?;

--- a/asahi-nvram/src/main.rs
+++ b/asahi-nvram/src/main.rs
@@ -76,16 +76,16 @@ fn real_main() -> Result<()> {
                     println!("{}", v);
                 }
             } else {
-                // for var in active.variables() {
-                //     println!("{}", var);
-                // }
-                for part in nv.partitions() {
-                    println!("{}", part);
-                    for var in part.variables() {
-                        println!("{}", var);
-                    }
-                    println!("========================================================")
+                for var in active.variables() {
+                    println!("{}", var);
                 }
+                // for part in nv.partitions() {
+                //     println!("{}", part);
+                //     for var in part.variables() {
+                //         println!("{}", var);
+                //     }
+                //     println!("========================================================")
+                // }
             }
         }
         Some(("write", args)) => {

--- a/asahi-nvram/src/main.rs
+++ b/asahi-nvram/src/main.rs
@@ -7,7 +7,7 @@ use std::{
     io::{Read, Seek, Write},
 };
 
-use apple_nvram::{erase_if_needed, Nvram, Section, UnescapeVal, Variable};
+use apple_nvram::{v3, erase_if_needed, Nvram, Section, UnescapeVal, Variable};
 
 #[derive(Debug)]
 enum Error {
@@ -31,8 +31,94 @@ impl From<apple_nvram::Error> for Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
-fn main() {
-    real_main().unwrap();
+fn main() -> Result<()> {
+    if let Err(_) = real_main() {
+        real_v3_main()?;
+    }
+    Ok(())
+}
+
+fn real_v3_main() -> Result<()> {
+    let matches = clap::command!()
+        .arg(clap::arg!(-d --device [DEVICE] "Path to the nvram device."))
+        .subcommand(
+            clap::Command::new("read")
+                .about("Read nvram variables")
+                .arg(clap::Arg::new("variable").multiple_values(true)),
+        )
+        .subcommand(
+            clap::Command::new("delete")
+                .about("Delete nvram variables")
+                .arg(clap::Arg::new("variable").multiple_values(true)),
+        )
+        .subcommand(
+            clap::Command::new("write")
+                .about("Write nvram variables")
+                .arg(clap::Arg::new("variable=value").multiple_values(true)),
+        )
+        .get_matches();
+    let default_name = "/dev/mtd0".to_owned();
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(matches.get_one::<String>("device").unwrap_or(&default_name))
+        .unwrap();
+    let mut data = Vec::new();
+    file.read_to_end(&mut data).unwrap();
+    let mut nv = v3::Nvram::parse(&data)?;
+    match matches.subcommand() {
+        Some(("read", args)) => {
+            let vars = args.get_many::<String>("variable");
+            if let Some(vars) = vars {
+                for var in vars {
+                    let (_, name) = var.split_once(':').ok_or(Error::MissingPartitionName)?;
+                    let v = nv.active_part_mut()
+                        .values
+                        .get(name.as_bytes())
+                        .ok_or(Error::VariableNotFound)?;
+                    println!("{}", v);
+                }
+            } else {
+                let part = nv.active_part_mut();
+                for var in part.values.values() {
+                    println!("{}", var);
+                }
+            }
+        }
+        // Some(("write", args)) => {
+        //     let vars = args.get_many::<String>("variable=value");
+        //     nv.prepare_for_write();
+        //     for var in vars.unwrap_or_default() {
+        //         let (key, value) = var.split_once('=').ok_or(Error::MissingValue)?;
+        //         let (part, name) = key.split_once(':').ok_or(Error::MissingPartitionName)?;
+        //         part_by_name(part, &mut nv)?.values.insert(
+        //             name.as_bytes(),
+        //             Variable {
+        //                 key: name.as_bytes(),
+        //                 value: Cow::Owned(read_var(value)?),
+        //             },
+        //         );
+        //     }
+        //     file.rewind().unwrap();
+        //     let data = nv.serialize()?;
+        //     erase_if_needed(&file, data.len());
+        //     file.write_all(&data).unwrap();
+        // }
+        // Some(("delete", args)) => {
+        //     let vars = args.get_many::<String>("variable");
+        //     nv.prepare_for_write();
+        //     for var in vars.unwrap_or_default() {
+        //         let (part, name) = var.split_once(':').ok_or(Error::MissingPartitionName)?;
+        //         part_by_name(part, &mut nv)?.values.remove(name.as_bytes());
+        //     }
+        //     file.rewind().unwrap();
+        //     let data = nv.serialize()?;
+        //     erase_if_needed(&file, data.len());
+        //     file.write_all(&data).unwrap();
+        // }
+        _ => {}
+    }
+    Ok(())
 }
 
 fn real_main() -> Result<()> {

--- a/asahi-nvram/src/main.rs
+++ b/asahi-nvram/src/main.rs
@@ -7,7 +7,7 @@ use std::{
     io::{Read, Seek, Write},
 };
 
-use apple_nvram::{v3, erase_if_needed, Nvram, Section, Variable, VarType};
+use apple_nvram::{erase_if_needed, Nvram, VarType};
 
 #[derive(Debug)]
 enum Error {
@@ -32,100 +32,97 @@ impl From<apple_nvram::Error> for Error {
 type Result<T> = std::result::Result<T, Error>;
 
 fn main() -> Result<()> {
-    if let Err(_) = real_main() {
-        real_v3_main()?;
-    }
-    Ok(())
+    real_main()
 }
 
-fn real_v3_main() -> Result<()> {
-    let matches = clap::command!()
-        .arg(clap::arg!(-d --device [DEVICE] "Path to the nvram device."))
-        .subcommand(
-            clap::Command::new("read")
-                .about("Read nvram variables")
-                .arg(clap::Arg::new("variable").multiple_values(true)),
-        )
-        .subcommand(
-            clap::Command::new("delete")
-                .about("Delete nvram variables")
-                .arg(clap::Arg::new("variable").multiple_values(true)),
-        )
-        .subcommand(
-            clap::Command::new("write")
-                .about("Write nvram variables")
-                .arg(clap::Arg::new("variable=value").multiple_values(true)),
-        )
-        .get_matches();
-    let default_name = "/dev/mtd0".to_owned();
-    let mut file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open(matches.get_one::<String>("device").unwrap_or(&default_name))
-        .unwrap();
-    let mut data = Vec::new();
-    file.read_to_end(&mut data).unwrap();
-    let nv = v3::Nvram::parse(&data)?;
-    match matches.subcommand() {
-        Some(("read", args)) => {
-            let vars = args.get_many::<String>("variable");
-            if let Some(vars) = vars {
-                for var in vars {
-                    let (_, name) = var.split_once(':').ok_or(Error::MissingPartitionName)?;
-                    let part = nv.active_part();
-                    let v = part
-                        .values
-                        .get(name.as_bytes())
-                        .ok_or(Error::VariableNotFound)?;
-                    println!("{}", v);
-                }
-            } else {
-                for part in nv.partitions() {
-                    println!("size: {}, generation: {}, state: 0x{:02x}, flags: 0x{:02x}, count: {}",
-                             part.header.size, part.generation(), part.header.state,
-                             part.header.flags, part.values.len());
-                    for var in part.values.values() {
-                        println!("{}", var);
-                    }
-                    println!("========================================================")
-                }
-            }
-        }
-        // Some(("write", args)) => {
-        //     let vars = args.get_many::<String>("variable=value");
-        //     nv.prepare_for_write();
-        //     for var in vars.unwrap_or_default() {
-        //         let (key, value) = var.split_once('=').ok_or(Error::MissingValue)?;
-        //         let (part, name) = key.split_once(':').ok_or(Error::MissingPartitionName)?;
-        //         part_by_name(part, &mut nv)?.values.insert(
-        //             name.as_bytes(),
-        //             Variable {
-        //                 key: name.as_bytes(),
-        //                 value: Cow::Owned(read_var(value)?),
-        //             },
-        //         );
-        //     }
-        //     file.rewind().unwrap();
-        //     let data = nv.serialize()?;
-        //     erase_if_needed(&file, data.len());
-        //     file.write_all(&data).unwrap();
-        // }
-        // Some(("delete", args)) => {
-        //     let vars = args.get_many::<String>("variable");
-        //     nv.prepare_for_write();
-        //     for var in vars.unwrap_or_default() {
-        //         let (part, name) = var.split_once(':').ok_or(Error::MissingPartitionName)?;
-        //         part_by_name(part, &mut nv)?.values.remove(name.as_bytes());
-        //     }
-        //     file.rewind().unwrap();
-        //     let data = nv.serialize()?;
-        //     erase_if_needed(&file, data.len());
-        //     file.write_all(&data).unwrap();
-        // }
-        _ => {}
-    }
-    Ok(())
-}
+// fn real_v3_main() -> Result<()> {
+//     let matches = clap::command!()
+//         .arg(clap::arg!(-d --device [DEVICE] "Path to the nvram device."))
+//         .subcommand(
+//             clap::Command::new("read")
+//                 .about("Read nvram variables")
+//                 .arg(clap::Arg::new("variable").multiple_values(true)),
+//         )
+//         .subcommand(
+//             clap::Command::new("delete")
+//                 .about("Delete nvram variables")
+//                 .arg(clap::Arg::new("variable").multiple_values(true)),
+//         )
+//         .subcommand(
+//             clap::Command::new("write")
+//                 .about("Write nvram variables")
+//                 .arg(clap::Arg::new("variable=value").multiple_values(true)),
+//         )
+//         .get_matches();
+//     let default_name = "/dev/mtd0".to_owned();
+//     let mut file = OpenOptions::new()
+//         .read(true)
+//         .write(true)
+//         .open(matches.get_one::<String>("device").unwrap_or(&default_name))
+//         .unwrap();
+//     let mut data = Vec::new();
+//     file.read_to_end(&mut data).unwrap();
+//     let mut nv = v3::Nvram::parse(&data)?;
+//     match matches.subcommand() {
+//         Some(("read", args)) => {
+//             let vars = args.get_many::<String>("variable");
+//             if let Some(vars) = vars {
+//                 for var in vars {
+//                     let (_, name) = var.split_once(':').ok_or(Error::MissingPartitionName)?;
+//                     let part = nv.active_part_mut();
+//                     let v = part
+//                         .values
+//                         .get(name.as_bytes())
+//                         .ok_or(Error::VariableNotFound)?;
+//                     println!("{}", v);
+//                 }
+//             } else {
+//                 for part in nv.partitions() {
+//                     println!("size: {}, generation: {}, state: 0x{:02x}, flags: 0x{:02x}, count: {}",
+//                              part.header.size, part.generation(), part.header.state,
+//                              part.header.flags, part.values.len());
+//                     for var in part.values.values() {
+//                         println!("{}", var);
+//                     }
+//                     println!("========================================================")
+//                 }
+//             }
+//         }
+//         // Some(("write", args)) => {
+//         //     let vars = args.get_many::<String>("variable=value");
+//         //     nv.prepare_for_write();
+//         //     for var in vars.unwrap_or_default() {
+//         //         let (key, value) = var.split_once('=').ok_or(Error::MissingValue)?;
+//         //         let (part, name) = key.split_once(':').ok_or(Error::MissingPartitionName)?;
+//         //         part_by_name(part, &mut nv)?.values.insert(
+//         //             name.as_bytes(),
+//         //             Variable {
+//         //                 key: name.as_bytes(),
+//         //                 value: Cow::Owned(read_var(value)?),
+//         //             },
+//         //         );
+//         //     }
+//         //     file.rewind().unwrap();
+//         //     let data = nv.serialize()?;
+//         //     erase_if_needed(&file, data.len());
+//         //     file.write_all(&data).unwrap();
+//         // }
+//         // Some(("delete", args)) => {
+//         //     let vars = args.get_many::<String>("variable");
+//         //     nv.prepare_for_write();
+//         //     for var in vars.unwrap_or_default() {
+//         //         let (part, name) = var.split_once(':').ok_or(Error::MissingPartitionName)?;
+//         //         part_by_name(part, &mut nv)?.values.remove(name.as_bytes());
+//         //     }
+//         //     file.rewind().unwrap();
+//         //     let data = nv.serialize()?;
+//         //     erase_if_needed(&file, data.len());
+//         //     file.write_all(&data).unwrap();
+//         // }
+//         _ => {}
+//     }
+//     Ok(())
+// }
 
 fn real_main() -> Result<()> {
     let matches = clap::command!()
@@ -157,41 +154,41 @@ fn real_main() -> Result<()> {
     let mut nv = Nvram::parse(&data)?;
     match matches.subcommand() {
         Some(("read", args)) => {
+            let active = nv.active_part_mut();
             let vars = args.get_many::<String>("variable");
             if let Some(vars) = vars {
                 for var in vars {
-                    let (part, name) = var.split_once(':').ok_or(Error::MissingPartitionName)?;
-                    let (p, _) = part_by_name(part, &mut nv)?;
-                    let v = p
-                        .values
-                        .get(name.as_bytes())
+                    let (_part, name) = var.split_once(':').ok_or(Error::MissingPartitionName)?;
+                    let v = active
+                        .get_variable(name.as_bytes())
                         .ok_or(Error::VariableNotFound)?;
                     println!("{}", v);
                 }
             } else {
-                let part = nv.active_part_mut();
-                for var in part.common.values.values() {
+                for var in active.variables() {
                     println!("{}", var);
                 }
-                for var in part.system.values.values() {
-                    println!("{}", var);
-                }
+                // for part in nv.partitions() {
+                //     println!("{}", part);
+                //     for var in part.variables() {
+                //         println!("{}", var);
+                //     }
+                //     println!("========================================================")
+                // }
             }
         }
         Some(("write", args)) => {
             let vars = args.get_many::<String>("variable=value");
             nv.prepare_for_write();
+            let mut active = nv.active_part_mut();
             for var in vars.unwrap_or_default() {
                 let (key, value) = var.split_once('=').ok_or(Error::MissingValue)?;
                 let (part, name) = key.split_once(':').ok_or(Error::MissingPartitionName)?;
-                let (p, typ) = part_by_name(part, &mut nv)?;
-                p.values.insert(
+                let typ = part_by_name(part)?;
+                active.insert_variable(
                     name.as_bytes(),
-                    Variable {
-                        key: name.as_bytes(),
-                        value: Cow::Owned(read_var(value)?),
-                        typ,
-                    },
+                    Cow::Owned(read_var(value)?),
+                    typ,
                 );
             }
             file.rewind().unwrap();
@@ -202,10 +199,11 @@ fn real_main() -> Result<()> {
         Some(("delete", args)) => {
             let vars = args.get_many::<String>("variable");
             nv.prepare_for_write();
+            let mut active = nv.active_part_mut();
             for var in vars.unwrap_or_default() {
                 let (part, name) = var.split_once(':').ok_or(Error::MissingPartitionName)?;
-                let (p, _) = part_by_name(part, &mut nv)?;
-                p.values.remove(name.as_bytes());
+                let typ = part_by_name(part)?;
+                active.remove_variable(name.as_bytes(), typ);
             }
             file.rewind().unwrap();
             let data = nv.serialize()?;
@@ -217,10 +215,10 @@ fn real_main() -> Result<()> {
     Ok(())
 }
 
-fn part_by_name<'a, 'b>(name: &str, nv: &'b mut Nvram<'a>) -> Result<(&'b mut Section<'a>, VarType)> {
+fn part_by_name(name: &str) -> Result<VarType> {
     match name {
-        "common" => Ok((&mut nv.active_part_mut().common, VarType::Common)),
-        "system" => Ok((&mut nv.active_part_mut().system, VarType::System)),
+        "common" => Ok(VarType::Common),
+        "system" => Ok(VarType::System),
         _ => Err(Error::UnknownPartition),
     }
 }

--- a/asahi-nvram/src/main.rs
+++ b/asahi-nvram/src/main.rs
@@ -27,8 +27,8 @@ impl From<apple_nvram::Error> for Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
-fn main() -> Result<()> {
-    real_main()
+fn main() {
+    real_main().unwrap()
 }
 
 fn real_main() -> Result<()> {

--- a/asahi-wifisync/src/main.rs
+++ b/asahi-wifisync/src/main.rs
@@ -16,6 +16,7 @@ use ini::Ini;
 enum Error {
     Parse,
     SectionTooBig,
+    ApplyError(std::io::Error),
     VariableNotFound,
     FileIO,
     IWDConfigDirNotFound,
@@ -26,6 +27,7 @@ impl From<apple_nvram::Error> for Error {
         match e {
             apple_nvram::Error::ParseError => Error::Parse,
             apple_nvram::Error::SectionTooBig => Error::SectionTooBig,
+            apple_nvram::Error::ApplyError(e) => Error::ApplyError(e),
         }
     }
 }

--- a/asahi-wifisync/src/main.rs
+++ b/asahi-wifisync/src/main.rs
@@ -8,7 +8,7 @@ use std::{
     path::Path,
 };
 
-use apple_nvram::{nvram_parse, Variable};
+use apple_nvram::{nvram_parse, VarType, Variable};
 
 use ini::Ini;
 
@@ -69,7 +69,7 @@ fn real_main() -> Result<()> {
     let mut nv = nvram_parse(&data)?;
     let active = nv.active_part_mut();
     let wlan_devs = active
-        .get_variable(wlan_var.as_bytes())
+        .get_variable(wlan_var.as_bytes(), VarType::System)
         .ok_or(Error::VariableNotFound)?;
 
     match matches.subcommand() {

--- a/asahi-wifisync/src/main.rs
+++ b/asahi-wifisync/src/main.rs
@@ -107,9 +107,7 @@ fn parse_wlan_info(var: &Variable) -> Vec<Network> {
         } else {
             None
         };
-        nets.push(Network{
-            ssid, psk
-        });
+        nets.push(Network { ssid, psk });
     }
 
     nets
@@ -131,11 +129,7 @@ fn print_wlankeys(var: &Variable) -> Result<()> {
         } else {
             "Open".to_owned()
         };
-        println!(
-            "SSID {}, {}",
-            network.ssid,
-            psk_str
-        );
+        println!("SSID {}, {}", network.ssid, psk_str);
     }
     Ok(())
 }


### PR DESCRIPTION
A new format is used for NVRAM variables on some Apple Silicon machines. I haven't verified this but it could also correspond to iBoot version (and/or macOS version) including the reported NVRAM size which recently changed rom 128 kB to 1 MB (as discussed in https://github.com/AsahiLinux/linux/issues/193).

Anyway, I split the code into two NVRAM implementations (v3 and v1v2) while also changing the API a little bit in order to abstract the format differences.

The original implementation still assumes 2 NVRAM banks (128 kB) and probably needs further adjustments to support both v1 and v2 (which are [very similar](https://github.com/apple-oss-distributions/xnu/blob/main/iokit/Kernel/IONVRAMCHRPHandler.cpp#L32) though).

One thing I noticed when toggling boot volume repeatedly (via macOS System Settings) is that the NVRAM generation does not change on every update (or even reboot). Instead, the state flag of modified variables is changed from 0x7F to 0x7C (curiously not found anywhere in the published Apple source code) and a new copy with updated value is appended to the NVRAM partition. I assume this happens until the bank is full and only after that it will increment the generation counter and use the next bank.

I din't want to complicate things so I just used in-place modification instead. I see no reason why it wouldn't work but I haven't tried it yet on my real machine. Last time I tried with a macOS VM (just to check what is inside the emulated NVRAM) it was still the old format.