### PR TITLE
asahi-nvram v3: we should only list active variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "apple-nvram"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "adler32",
  "crc32fast",
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "asahi-bless"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "apple-nvram",
  "gpt",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "asahi-btsync"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "apple-nvram",
  "clap",
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "asahi-nvram"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "apple-nvram",
  "clap",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "asahi-wifisync"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "apple-nvram",
  "clap",


### PR DESCRIPTION
This is one thing I forgot about. Originally, I was printing all versions of variables for debugging purposes, then the flags were removed from the Display trait but the asahi-nvram read operation still lists all variables including the invalidated ones.

For consistency, we should only list variables with the VAR_ADDED flag.

I also simplified storage of the variables. Originally, I used map then I realised I want to preserve order but I changed it to a vector of tuples with the key actually stored twice (by itself and as part of the value). This is obviously redundant so I'm fixing it.

Sorry I didn't make it before the 0.2 release.