### PR TITLE
asahi-bless: non-interactive mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a318f1f38d2418400f8209655bfd825785afd25aa30bb7ba6cc792e4596748"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "apple-nvram"
 version = "0.2.1"
 dependencies = [
@@ -30,9 +78,10 @@ dependencies = [
 
 [[package]]
 name = "asahi-bless"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "apple-nvram",
+ "clap 4.4.11",
  "gpt",
  "uuid",
 ]
@@ -42,7 +91,7 @@ name = "asahi-btsync"
 version = "0.2.0"
 dependencies = [
  "apple-nvram",
- "clap",
+ "clap 3.2.25",
  "rust-ini",
 ]
 
@@ -51,7 +100,7 @@ name = "asahi-nvram"
 version = "0.2.1"
 dependencies = [
  "apple-nvram",
- "clap",
+ "clap 3.2.25",
 ]
 
 [[package]]
@@ -59,7 +108,7 @@ name = "asahi-wifisync"
 version = "0.2.0"
 dependencies = [
  "apple-nvram",
- "clap",
+ "clap 3.2.25",
  "rust-ini",
 ]
 
@@ -106,12 +155,46 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex 0.6.0",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -122,6 +205,18 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "crc"
@@ -184,6 +279,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -268,6 +369,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +409,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "syn"
+version = "2.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +433,18 @@ name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
@@ -355,3 +497,69 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"

--- a/asahi-bless/Cargo.toml
+++ b/asahi-bless/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/WhatAmISupposedToPutHere/asahi-nvram"
 [dependencies]
 uuid = "1"
 gpt = "3"
+clap = { version = "4.4.11", features = ["derive"] }
 
 [dependencies.apple-nvram]
 path = "../apple-nvram"

--- a/asahi-bless/src/lib.rs
+++ b/asahi-bless/src/lib.rs
@@ -242,6 +242,7 @@ pub enum Error {
     SectionTooBig,
     ApplyError(std::io::Error),
     OutOfRange,
+    Ambiguous,
 }
 
 impl From<apple_nvram::Error> for Error {

--- a/asahi-bless/src/main.rs
+++ b/asahi-bless/src/main.rs
@@ -1,13 +1,44 @@
 // SPDX-License-Identifier: MIT
 #![allow(dead_code)]
-use asahi_bless::{get_boot_candidates, get_boot_volume, set_boot_volume, Error};
+use asahi_bless::{get_boot_candidates, get_boot_volume, set_boot_volume, BootCandidate, Error};
+use clap::Parser;
 use std::{
-    env,
     io::{stdin, stdout, Write},
     process::ExitCode,
 };
 
 type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Parser)]
+struct Args {
+    #[arg(
+        short,
+        long,
+        help = "Use alt-boot-volume to get/set default boot volume"
+    )]
+    next: bool,
+
+    #[arg(
+        short,
+        long,
+        conflicts_with_all = &["set_boot", "set_boot_macos"],
+        help = "List boot volume candidates"
+    )]
+    list_volumes: bool,
+
+    #[arg(long, value_name = "idx", help = "Set boot volume by index")]
+    set_boot: Option<isize>,
+
+    #[arg(
+        long,
+        conflicts_with = "set_boot",
+        help = "Set boot volume to macOS if unambiguous"
+    )]
+    set_boot_macos: bool,
+
+    #[arg(name = "yes", short, long, help = "Do not ask for confirmation")]
+    autoconfirm: bool,
+}
 
 fn main() -> ExitCode {
     match real_main() {
@@ -20,14 +51,48 @@ fn main() -> ExitCode {
 }
 
 fn real_main() -> Result<()> {
-    let mut next: bool = false;
-    for arg in env::args() {
-        if arg == "--next" || arg == "-n" {
-            next = true;
+    let args = Args::parse();
+
+    if args.list_volumes {
+        list_boot_volumes(&args)?;
+    } else if let Some(idx) = args.set_boot {
+        let cands = get_boot_candidates()?;
+        set_boot_volume_by_index(&cands, idx - 1, &args)?;
+    } else if args.set_boot_macos {
+        let cands = get_boot_candidates()?;
+        let macos_cands: Vec<_> = cands
+            .iter()
+            .filter(|c| {
+                c.vol_names
+                    .first()
+                    .map(|n| n.starts_with("Macintosh"))
+                    .unwrap_or(false)
+            })
+            .collect();
+        if macos_cands.len() == 1 {
+            set_boot_volume_by_ref(&macos_cands[0], &args)?;
+        } else {
+            eprintln!("ambiguous boot volume");
+            return Err(Error::Ambiguous);
         }
+    } else {
+        interactive_main(&args)?;
     }
-    let cands = get_boot_candidates().unwrap();
-    let default_cand = get_boot_volume(next).unwrap();
+
+    Ok(())
+}
+
+fn confirm() -> bool {
+    print!("confirm? [y/N]: ");
+    stdout().flush().unwrap();
+    let mut input = String::new();
+    stdin().read_line(&mut input).unwrap();
+    input.trim().to_lowercase() == "y"
+}
+
+fn list_boot_volumes(args: &Args) -> Result<Vec<BootCandidate>> {
+    let cands = get_boot_candidates()?;
+    let default_cand = get_boot_volume(args.next)?;
     let mut is_default: &str;
     for (i, cand) in cands.iter().enumerate() {
         if (cand.part_uuid == default_cand.part_uuid) && (cand.vg_uuid == default_cand.vg_uuid) {
@@ -37,15 +102,34 @@ fn real_main() -> Result<()> {
         }
         println!("{}{}) {}", is_default, i + 1, cand.vol_names.join(", "));
     }
+    Ok(cands)
+}
+
+fn set_boot_volume_by_index(cands: &[BootCandidate], idx: isize, args: &Args) -> Result<()> {
+    if idx < 0 || idx as usize >= cands.len() {
+        eprintln!("index out of range");
+        return Err(Error::OutOfRange);
+    }
+    set_boot_volume_by_ref(&cands[idx as usize], args)
+}
+
+fn set_boot_volume_by_ref(cand: &BootCandidate, args: &Args) -> Result<()> {
+    println!("picked {}", cand.vol_names.join(", "));
+    if !args.autoconfirm && !confirm() {
+        return Ok(());
+    }
+    set_boot_volume(cand, args.next)?;
+    println!("boot volume set");
+    Ok(())
+}
+
+fn interactive_main(args: &Args) -> Result<()> {
+    let cands = list_boot_volumes(args)?;
     print!("==> ");
     stdout().flush().unwrap();
     let mut input = String::new();
     stdin().read_line(&mut input).unwrap();
-    let ix = input.trim().parse::<usize>().unwrap() - 1;
-    if ix >= cands.len() {
-        eprintln!("index out of range");
-        return Err(Error::OutOfRange);
-    };
-    set_boot_volume(&cands[ix], next)?;
+    let ix = input.trim().parse::<isize>().unwrap() - 1;
+    set_boot_volume_by_index(&cands, ix, args)?;
     Ok(())
 }


### PR DESCRIPTION
I would like to use asahi-bless non-interactively, so I added a couple of useful command-line parameters.
It is still possible to run it without any arguments except now it will ask for confirmation before setting the boot volume (unless `-y` is used).
