### PR TITLE
More graceful handling of invalid inputs

### DIFF
--- a/asahi-bless/src/main.rs
+++ b/asahi-bless/src/main.rs
@@ -148,6 +148,7 @@ fn set_boot_volume_by_ref(cand: &BootCandidate, args: &Args, interactive: bool) 
 
 fn interactive_main(args: &Args) -> Result<()> {
     let cands = list_boot_volumes(args)?;
+    println!("\nEnter a number to select a boot volume:");
 
     let mut input = String::new();
     let index = loop {


### PR DESCRIPTION
An ideal behaviour (in my view) would be for the interactive mode to loop until it gets a valid input, but handling invalid or empty strings properly is still far better than just letting the program panic.