### PR TITLE
apple-nvram library: important lifetime bug-fixes

### DIFF
--- a/apple-nvram/src/lib.rs
+++ b/apple-nvram/src/lib.rs
@@ -87,7 +87,7 @@ pub trait Nvram<'a> {
 
 pub trait Partition<'a>: Display {
     fn variables(&self) -> Box<dyn Iterator<Item = &dyn Variable<'a>> + '_>;
-    fn get_variable(&self, key: &'a [u8], typ: VarType) -> Option<&dyn Variable<'a>>;
+    fn get_variable(&self, key: &[u8], typ: VarType) -> Option<&dyn Variable<'a>>;
     fn insert_variable(&mut self, key: &'a [u8], value: Cow<'a, [u8]>, typ: VarType);
     fn remove_variable(&mut self, key: &'a [u8], typ: VarType);
 }

--- a/apple-nvram/src/lib.rs
+++ b/apple-nvram/src/lib.rs
@@ -88,8 +88,8 @@ pub trait Nvram<'a> {
 pub trait Partition<'a>: Display {
     fn variables(&self) -> Box<dyn Iterator<Item = &dyn Variable<'a>> + '_>;
     fn get_variable(&self, key: &[u8], typ: VarType) -> Option<&dyn Variable<'a>>;
-    fn insert_variable(&mut self, key: &'a [u8], value: Cow<'a, [u8]>, typ: VarType);
-    fn remove_variable(&mut self, key: &'a [u8], typ: VarType);
+    fn insert_variable(&mut self, key: &[u8], value: Cow<'a, [u8]>, typ: VarType);
+    fn remove_variable(&mut self, key: &[u8], typ: VarType);
 }
 
 pub trait Variable<'a>: Display {


### PR DESCRIPTION
The lifetime of variable `key` was incorrectly tied to the raw NVRAM data buffer.

Internally, the parsed representation of NVRAM can still contain references to the original bytes, however, in the API, we must be able to pass references to keys with entirely independent lifetimes (in which case the key is cloned into a `Cow::Owned`).

I don't want to do a breaking API change, so I always pass the key by reference except it no longer has the `'a` lifetime which was too constraining for practical use.