### PR TITLE
Generic implementation of NvramWriter, removed useless type wrapper.

### DIFF
--- a/apple-nvram/src/mtd.rs
+++ b/apple-nvram/src/mtd.rs
@@ -1,29 +1,30 @@
 use std::{
-    fs::File,
     io::{Seek, SeekFrom, Write},
     os::unix::io::AsRawFd,
 };
 
 use crate::NvramWriter;
 
-pub struct MtdWriter {
-    file: File,
-}
-
-impl MtdWriter {
-    pub fn new(file: File) -> MtdWriter {
-        MtdWriter { file }
-    }
-}
-
-impl NvramWriter for MtdWriter {
+impl<T> NvramWriter for T
+where
+    T: Seek + Write + AsRawFd,
+{
     fn erase_if_needed(&mut self, offset: u32, size: usize) {
-        erase_if_needed(&self.file, offset, size);
+        if unsafe { mtd_mem_get_info(self.as_raw_fd(), &mut MtdInfoUser::default()) }.is_err() {
+            return;
+        }
+        let erase_info = EraseInfoUser {
+            start: offset,
+            length: size as u32,
+        };
+        unsafe {
+            mtd_mem_erase(self.as_raw_fd(), &erase_info).unwrap();
+        }
     }
 
     fn write_all(&mut self, offset: u32, buf: &[u8]) -> std::io::Result<()> {
-        self.file.seek(SeekFrom::Start(offset as u64))?;
-        self.file.write_all(buf)?;
+        self.seek(SeekFrom::Start(offset as u64))?;
+        self.write_all(buf)?;
 
         Ok(())
     }
@@ -49,16 +50,3 @@ pub struct MtdInfoUser {
 
 nix::ioctl_write_ptr!(mtd_mem_erase, b'M', 2, EraseInfoUser);
 nix::ioctl_read!(mtd_mem_get_info, b'M', 1, MtdInfoUser);
-
-fn erase_if_needed(file: &File, offset: u32, size: usize) {
-    if unsafe { mtd_mem_get_info(file.as_raw_fd(), &mut MtdInfoUser::default()) }.is_err() {
-        return;
-    }
-    let erase_info = EraseInfoUser {
-        start: offset,
-        length: size as u32,
-    };
-    unsafe {
-        mtd_mem_erase(file.as_raw_fd(), &erase_info).unwrap();
-    }
-}

--- a/asahi-nvram/src/main.rs
+++ b/asahi-nvram/src/main.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 use std::{borrow::Cow, fs::OpenOptions, io::Read, process::ExitCode};
 
-use apple_nvram::{mtd::MtdWriter, nvram_parse, VarType};
+use apple_nvram::{nvram_parse, VarType};
 
 #[derive(Debug)]
 enum Error {
@@ -95,7 +95,7 @@ fn real_main() -> Result<()> {
                 let typ = part_by_name(part)?;
                 active.insert_variable(name.as_bytes(), Cow::Owned(read_var(value)?), typ);
             }
-            nv.apply(&mut MtdWriter::new(file))?;
+            nv.apply(&mut file)?;
         }
         Some(("delete", args)) => {
             let vars = args.get_many::<String>("variable");
@@ -106,7 +106,7 @@ fn real_main() -> Result<()> {
                 let typ = part_by_name(part)?;
                 active.remove_variable(name.as_bytes(), typ);
             }
-            nv.apply(&mut MtdWriter::new(file))?;
+            nv.apply(&mut file)?;
         }
         _ => {}
     }


### PR DESCRIPTION
The `MtdWriter` wrapper I originally introduced is problematic (because it's taking ownership of the `File`) and also kind of useless. Trait `NvramWriter` can be implemented for any file-like type directly.

```
impl<T> NvramWriter for T
where
    T: Seek + Write + AsRawFd,
```

This enables me to do things like file locking:

```
use nix::fcntl::{Flock, FlockArg};

let file = OpenOptions::new().write(true).open(path)?;
let mut file = Flock::lock(file, FlockArg::LockExclusive).map_err(|(_, e)| e)?;
nv.apply(&mut *file)?;
```

Here, the `Flock` type implements `DerefMut` but isn't `Seek + Write + AsRawFd` directly. If I had to move it into a wrapper, I wouldn't be able to easily express the wrapped value generic type.