### PR TITLE
Open MTD device by device name 

### DIFF
--- a/asahi-bless/src/lib.rs
+++ b/asahi-bless/src/lib.rs
@@ -313,7 +313,7 @@ pub fn get_boot_volume(next: bool) -> Result<BootCandidate> {
     let mut file = OpenOptions::new()
         .read(true)
         .write(true)
-        .open("/dev/mtd0")
+        .open("/dev/mtd/by-name/nvram")
         .map_err(Error::NvramReadError)?;
     let mut data = Vec::new();
     file.read_to_end(&mut data).map_err(Error::NvramReadError)?;
@@ -346,7 +346,7 @@ pub fn clear_next_boot() -> Result<bool> {
     let mut file = OpenOptions::new()
         .read(true)
         .write(true)
-        .open("/dev/mtd0")
+        .open("/dev/mtd/by-name/nvram")
         .map_err(Error::ApplyError)?;
     let mut data = Vec::new();
     file.read_to_end(&mut data).map_err(Error::ApplyError)?;
@@ -381,7 +381,7 @@ pub fn set_boot_volume(cand: &BootCandidate, next: bool) -> Result<()> {
     let mut file = OpenOptions::new()
         .read(true)
         .write(true)
-        .open("/dev/mtd0")
+        .open("/dev/mtd/by-name/nvram")
         .map_err(Error::ApplyError)?;
     let mut data = Vec::new();
     file.read_to_end(&mut data).map_err(Error::ApplyError)?;

--- a/asahi-btsync/src/main.rs
+++ b/asahi-btsync/src/main.rs
@@ -68,7 +68,7 @@ fn real_main() -> Result<()> {
         )
         .get_matches();
 
-    let default_name = "/dev/mtd0ro".to_owned();
+    let default_name = "/dev/mtd/by-name/nvram".to_owned();
     let default_config = "/var/lib/bluetooth".to_owned();
     let bt_var = "BluetoothUHEDevices";
 

--- a/asahi-nvram/src/main.rs
+++ b/asahi-nvram/src/main.rs
@@ -57,7 +57,7 @@ fn real_main() -> Result<()> {
                 .arg(clap::Arg::new("variable=value").multiple_values(true)),
         )
         .get_matches();
-    let default_name = "/dev/mtd0".to_owned();
+    let default_name = "/dev/mtd/by-name/nvram".to_owned();
     let mut file = OpenOptions::new()
         .read(true)
         .write(true)

--- a/asahi-wifisync/src/main.rs
+++ b/asahi-wifisync/src/main.rs
@@ -57,7 +57,7 @@ fn real_main() -> Result<()> {
         )
         .get_matches();
 
-    let default_name = "/dev/mtd0ro".to_owned();
+    let default_name = "/dev/mtd/by-name/nvram".to_owned();
     let default_config = "/var/lib/iwd".to_owned();
     let wlan_var = "preferred-networks";
 


### PR DESCRIPTION
"nvram" will not be the sole MTD device on AsahiLinux devices with
m1n1-1.4.16 (https://github.com/AsahiLinux/m1n1/pull/399) and
CONFIG_MTD_PHRAM. Use "/dev/mtd/by-name/nvram" instead of "/dev/mtd0".